### PR TITLE
feat(teams): direct HTTP client with MSAL token extraction

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 set -e
 
 pnpm exec lint-staged
+pnpm check:ts-guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 ## Repository-wide conventions
 
 - Package names, paths, and CLI names stay lowercase (`clawpilot`); human-facing product naming is `Clawpilot`.
+- Follow `docs/typescript-guidelines.md` for maintainable TypeScript design. Treat it as the written guidance, and remember staged `.ts`/`.tsx` changes are checked by the pre-commit TypeScript guideline hook in addition to lint-staged.
 - Keep `auth login` visible for manual sign-in. Background/non-login browser work should stay unobtrusive by default.
 - Reuse existing helpers for browser state, output formatting, and window behavior before adding new browser utilities.
 - Always work through a pull request for code changes: create or update a branch, open or update the PR, explicitly request Copilot review if it was not auto-requested, address review comments one by one, and reply to each review comment one by one with the resolution or rationale.

--- a/README.md
+++ b/README.md
@@ -85,11 +85,20 @@ node packages/clawpilot-browser/dist/index.js web search "your query" [--max-res
 # Fetch and extract content from a URL
 node packages/clawpilot-browser/dist/index.js web fetch "https://example.com" [--readability]
 
+# List Teams chats and channels (default page size: 20)
+node packages/clawpilot-browser/dist/index.js teams list [--limit 20] [--offset 0] [--json]
+
+# Read a specific Teams chat/channel by id from `teams list`
+node packages/clawpilot-browser/dist/index.js teams read "<id>" [--limit 20] [--offset 0] [--json]
+
 # Validate whether the saved Office session still works
 node packages/clawpilot-browser/dist/index.js auth status --validate
 
 # Run the end-to-end manual browser QA script
 packages/clawpilot-browser/scripts/manual-test-web.sh
+
+# Run the Teams discovery/read manual QA script
+packages/clawpilot-browser/scripts/manual-test-teams.sh
 ```
 
 `auth status`, `auth status --validate`, and `health check-session` now include stored

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ pnpm test:watch
 pnpm lint
 ```
 
+TypeScript engineering guidance for this repo lives in [`docs/typescript-guidelines.md`](./docs/typescript-guidelines.md).
+The pre-commit hook runs `lint-staged` plus a staged-file guideline check for changed `.ts` and `.tsx` files.
+
 ## Project-local agent skills
 
 - `.agents/skills/typescript-pro` vendors a strong TypeScript specialist skill into the repo.

--- a/docs/clawpilot-project.md
+++ b/docs/clawpilot-project.md
@@ -17,6 +17,8 @@ It is inspired by [pi](https://github.com/badlogic/pi-mono) (the minimal agent f
 - **Personality-driven**: A configurable "soul" defines how Clawpilot communicates — tone, proactiveness, summary style, boundaries. The soul evolves as the agent learns your preferences.
 - **Graceful degradation**: Clawpilot detects whether Playwright is available and whether browser sessions are valid. When browser tools aren't available, it continues working with non-browser tools (CLI skills, file system, bash) and clearly reports what's degraded.
 
+TypeScript implementation guidance for maintainability and repo-specific engineering rules lives in [`docs/typescript-guidelines.md`](./typescript-guidelines.md).
+
 ### What It Does (Day in the Life)
 
 1. You open your laptop at 8am. Clawpilot starts, runs the morning briefing workflow: checks your Outlook calendar, queries your Jira board, searches Teams channels for overnight activity, and presents a briefing via desktop notification and the REPL log.
@@ -372,6 +374,7 @@ The search commands use the native search functionality built into Teams and Out
 - On subsequent use: Playwright launches with saved context, window minimised (headed but hidden)
 - Session expiry detection: if a page navigation lands on a login URL, CLI exits with a specific error code and message
 - Browser mode is **on-demand** by default: launch Chromium when a command is called, do the work, close. Configurable to **persistent** mode for lower latency
+- Implementation details for the current Teams runtime live in [`docs/teams-integration.md`](./teams-integration.md)
 
 **Health Check System:**
 
@@ -1336,6 +1339,7 @@ Complete list of tools available to the Clawpilot agent:
 - Teams: read messages from channels and chats
 - **Teams search**: search channels and chats by keyword with date filters
 - Teams: list channels, send messages
+- See [`docs/teams-integration.md`](./teams-integration.md) for the current auth, browser, token, and API flow used by the implemented Teams commands
 
 #### Step 4: clawpilot-browser — Outlook & Web
 

--- a/docs/teams-integration.md
+++ b/docs/teams-integration.md
@@ -1,0 +1,148 @@
+# Teams integration
+
+This document explains how the current Teams integration in `@clawpilot/browser` works.
+
+## What the integration does today
+
+The implemented Teams commands are:
+
+- `clawpilot-browser auth login`
+- `clawpilot-browser auth status --validate`
+- `clawpilot-browser teams list`
+- `clawpilot-browser teams read "<id>"`
+
+`teams list` returns recent chats and channels. `teams read` reads messages for a specific chat or channel id returned by `teams list`.
+
+## High-level runtime model
+
+The integration uses both a browser session and direct Teams HTTP APIs.
+
+The browser is used to:
+
+- launch a persistent signed-in Microsoft 365 session
+- reuse stored cookies and browser state from `~/.clawpilot/state/browser-state/`
+- inspect Teams web app state
+- extract MSAL access tokens from Teams local storage when available
+
+The direct APIs are used to:
+
+- bootstrap the current Teams region and partition
+- list chats
+- fetch messages for a chat
+
+This hybrid approach keeps login interactive and reliable while making reads much faster than full DOM scraping.
+
+## Browser and session handling
+
+Manual sign-in happens through `auth login`.
+
+- It launches a visible headed browser.
+- The user completes Microsoft login and MFA manually.
+- The session is saved in `~/.clawpilot/state/browser-state/`.
+- A login is considered successful when Teams lands on an authenticated app URL, including both `teams.microsoft.com` and `teams.cloud.microsoft`.
+
+Non-login commands reuse the saved browser state through Playwright persistent contexts. The shared launch helper now uses Playwright's `channel: 'chrome'` so the automation runs against installed Google Chrome instead of Chrome for Testing. That matters because Teams proved more reliable in full Chrome on this machine.
+
+For background work, the window is launched small and offscreen, then minimized where Chromium allows it. `auth login` stays visibly interactive by design.
+
+## Primary data flow
+
+The main implementation lives in `packages/clawpilot-browser/src/teams.ts`.
+
+### 1. Load the Teams shell
+
+`listTeams()` and `readTeams()` open `https://teams.cloud.microsoft`, then fall back to `https://teams.microsoft.com/v2/` if needed.
+
+The code waits briefly for the app shell to render before deciding whether the page is healthy, needs recovery, or requires interactive auth.
+
+### 2. Confirm auth readiness
+
+The runtime accepts both major Teams web origins:
+
+- `https://teams.microsoft.com`
+- `https://teams.cloud.microsoft`
+
+If the page is already on the cloud app origin, that is treated as a valid authenticated Teams surface. This avoids forcing unnecessary login loops when Teams has already redirected away from the legacy host.
+
+If the page is not ready, the code can make the window visible and trigger interactive login inside Teams.
+
+### 3. Extract Teams access tokens from MSAL cache
+
+Once the Teams app is loaded, the integration reads local storage and looks for MSAL access token entries. It needs three token audiences:
+
+- `https://api.spaces.skype.com`
+- `https://chatsvcagg.teams.microsoft.com`
+- `https://ic3.teams.office.com`
+
+If all three are present, the integration uses the direct API path.
+
+### 4. Bootstrap Teams routing information
+
+The first API call is:
+
+- `POST https://teams.microsoft.com/api/authsvc/v1.0/authz`
+
+This returns routing metadata such as the active region and partition, plus a Skype token in the response payload.
+
+### 5. Read chats and messages
+
+After bootstrap:
+
+- `teams list` calls `GET https://teams.cloud.microsoft/api/csa/{region}/api/v1/teams/users/me/groupchats?skipMeetingChats=true`
+- `teams read` calls `GET https://teams.cloud.microsoft/api/chatsvc/{region}/v1/users/ME/conversations/{id}/messages?...`
+
+The direct responses are normalized into the CLI's output shapes before being printed as formatted text or JSON.
+
+## Fallback behavior
+
+If token extraction fails or direct API calls fail, the integration falls back to browser-side DOM collection.
+
+That fallback:
+
+- scans the Teams UI for chat and channel nodes
+- normalizes links and dataset attributes into stable ids
+- opens a target chat when needed
+- extracts visible message nodes from the page
+
+This keeps the commands usable even when the token-based fast path is unavailable.
+
+## Error handling and recovery
+
+The code includes explicit handling for a few Teams-specific failure modes:
+
+- login pages and expired sessions
+- Teams retry-shell errors
+- auth probe timeouts
+- empty token cache
+- direct API failures
+- DOM fallback returning no usable chats or messages
+
+Retry-shell detection is intentionally strict. It now only treats the page as broken when the page looks like the real Teams error shell, not merely because some unrelated `Retry` button exists somewhere in the app DOM.
+
+## Validation and tests
+
+Relevant code and tests:
+
+- `packages/clawpilot-browser/src/teams.ts`
+- `packages/clawpilot-browser/src/browser.ts`
+- `packages/clawpilot-browser/src/utils/window.ts`
+- `packages/clawpilot-browser/src/__tests__/teams.test.ts`
+- `packages/clawpilot-browser/src/__tests__/browser.test.ts`
+- `packages/clawpilot-browser/src/utils/__tests__/window.test.ts`
+
+Manual verification helpers:
+
+- `node packages/clawpilot-browser/dist/index.js auth status --validate`
+- `node packages/clawpilot-browser/dist/index.js teams list --json`
+- `node packages/clawpilot-browser/dist/index.js teams read "<id>" --json`
+- `packages/clawpilot-browser/scripts/manual-test-teams.sh`
+
+## Current design intent
+
+The integration is optimized around a simple rule:
+
+- use the browser to stay signed in and discover runtime auth state
+- use direct Teams APIs when possible
+- fall back to DOM interaction only when necessary
+
+That gives the CLI a practical balance of reliability, speed, and debuggability.

--- a/docs/typescript-guidelines.md
+++ b/docs/typescript-guidelines.md
@@ -1,0 +1,118 @@
+# TypeScript engineering guidelines
+
+This repository is still early, which is exactly when good TypeScript habits matter most. These guidelines are intended to keep the codebase robust, maintainable, and elegant while it is still small enough to shape deliberately.
+
+They combine general TypeScript engineering advice with repository-specific conventions already used in Clawpilot.
+
+## Core principles
+
+### 1. Keep modules focused
+
+- Prefer small modules with one clear reason to change.
+- Use named exports by default.
+- Avoid default exports in source modules.
+- Keep public module APIs small and intentional.
+- If the same logic appears in multiple places, extract a shared helper instead of copying it again.
+
+### 2. Keep boundaries explicit
+
+- Be explicit at module boundaries: exported functions, command handlers, parsers, and public helpers should have clear parameter and return types.
+- Let TypeScript infer obvious local variables inside small scopes, but do not rely on inference to define public contracts.
+- Model invalid states explicitly with unions, nullable types, and type guards instead of relying on convention.
+
+### 3. Prefer safe types over convenient types
+
+- Do not use `any` in normal application code.
+- Prefer `unknown` plus narrowing when input is genuinely dynamic.
+- Avoid double assertions such as `as unknown as T`.
+- Reuse shared shapes and utility types instead of inventing one-off near-duplicates.
+
+### 4. Make dependencies obvious
+
+- Keep imports directional and boring.
+- Inside package source trees, do not use relative imports between source modules; import through the package alias instead.
+- Avoid hidden coupling between features. If two modules share policy or validation rules, centralize the rule rather than duplicating it.
+
+### 5. Be strict about error handling
+
+- Do not swallow errors silently.
+- Avoid broad catch blocks unless they are truly best-effort and documented locally.
+- When an operation can fail in expected ways, return a clear result shape or surface a precise error.
+- Add context to errors at boundaries instead of losing the original cause.
+
+### 6. Optimize for changeability
+
+- Prefer straightforward code over clever code.
+- Avoid deep nesting, nested ternaries, and large mixed-responsibility files.
+- Delete dead code and obsolete paths instead of preserving parallel variants.
+- Keep comments for intent and trade-offs, not line-by-line narration.
+
+### 7. Keep tests and docs close to behavior
+
+- When behavior changes, update tests and directly related documentation.
+- Test parsing, validation, and branching logic close to where it lives.
+- Prefer fast feedback on changed files locally and full verification before pushing.
+
+## Repository-specific rules
+
+These are especially important in Clawpilot:
+
+- Use package-root imports inside packages, not `./...` or `../...`.
+- Reuse shared browser helpers, output helpers, and path helpers before creating new ones.
+- Keep command modules thin.
+- Keep policy centralized.
+- Prefer editing existing primitives over adding parallel implementations.
+
+## How the repository enforces this
+
+The repository uses two layers of enforcement:
+
+### Existing automated checks
+
+- `eslint`
+- `typescript-eslint` strict rules
+- `lint-staged`
+- package type checks and tests
+
+### TypeScript guideline hook
+
+The pre-commit hook now runs a repository-local TypeScript guideline checker on staged `.ts` and `.tsx` files.
+
+It hard-fails on a deliberately objective subset of these rules:
+
+- `@ts-ignore` and `@ts-nocheck`
+- explicit `any` patterns in non-test files
+- double assertions such as `as unknown as` in non-test files
+- default exports in package source files
+- relative imports inside `packages/*/src`
+- `TODO`, `FIXME`, and `HACK` markers in changed TypeScript files
+
+It also emits warnings for softer maintainability heuristics:
+
+- large files
+- many exports from one file
+- nested ternaries
+- empty catch blocks
+
+Those warnings are intentionally advisory: they indicate code that deserves a second look, but they are not precise enough to be universal hard failures.
+
+## Working rule of thumb
+
+When writing TypeScript in this repo, aim for code that is:
+
+- explicit at boundaries
+- narrow in responsibility
+- strict in typing
+- boring in dependencies
+- honest in error handling
+- easy to change later
+
+## Sources that informed these guidelines
+
+These guidelines were informed by external TypeScript engineering recommendations and adapted to Clawpilot's current architecture:
+
+- Feature-Sliced Design — TypeScript architecture guidance: <https://feature-sliced.design/blog/typescript-architecture-tips>
+- Project Rules — TypeScript coding standards: <https://www.projectrules.ai/rules/typescript>
+- Bacancy — TypeScript strictness and maintainability practices: <https://www.bacancytechnology.com/blog/typescript-best-practices>
+- Syskool — Husky + lint-staged for TypeScript monorepos: <https://syskool.com/setting-up-pre-commit-hooks-husky-lint-staged-for-typescript-monorepos/>
+- Samuel Lawrentz — enforcing coding standards with TypeScript, Husky, and lint-staged: <https://samuellawrentz.com/blog/coding-standards-husky-typescript-lint-staged/>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A personal AI agent that runs on your laptop, learns from you, and gets things done.",
   "scripts": {
     "build": "pnpm -r build",
+    "check:ts-guidelines": "node scripts/check-typescript-guidelines.mjs --staged",
     "test": "pnpm -r test",
     "lint": "eslint . && pnpm -r lint",
     "format": "prettier --write .",

--- a/packages/clawpilot-browser/scripts/manual-test-teams.sh
+++ b/packages/clawpilot-browser/scripts/manual-test-teams.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+CLI="node $(dirname "$0")/../dist/index.js"
+PASS=0
+FAIL=0
+
+run_test() {
+  NAME="$1"
+  shift
+
+  printf '\n=== %s ===\n' "$NAME"
+  printf 'Command: %s' "$CLI"
+  for arg in "$@"; do
+    printf ' "%s"' "$arg"
+  done
+  printf '\n'
+
+  if $CLI "$@"; then
+    PASS=$((PASS + 1))
+    printf 'Result: PASS\n'
+  else
+    FAIL=$((FAIL + 1))
+    printf 'Result: FAIL\n'
+  fi
+}
+
+extract_first_id() {
+  node <<'NODE'
+const fs = require('fs');
+try {
+  const payload = JSON.parse(fs.readFileSync(0, 'utf8'));
+  if (!payload.ok || !payload.data) {
+    process.exit(0);
+  }
+
+  const firstChat = payload.data.chats?.[0]?.id;
+  const firstChannel = payload.data.channels?.[0]?.id;
+  if (firstChat) {
+    process.stdout.write(firstChat);
+    process.exit(0);
+  }
+  if (firstChannel) {
+    process.stdout.write(firstChannel);
+  }
+} catch {
+  process.exit(0);
+}
+NODE
+}
+
+printf '%s\n' 'Clawpilot Browser — Teams Commands Manual Test'
+
+run_test 'teams list' teams list
+run_test 'teams list --json' teams list --json
+
+LIST_JSON="$($CLI teams list --json 2>/dev/null || true)"
+FIRST_ID="$(printf '%s' "$LIST_JSON" | extract_first_id)"
+
+if [ -n "$FIRST_ID" ]; then
+  run_test "teams read $FIRST_ID" teams read "$FIRST_ID"
+  run_test "teams read $FIRST_ID --json" teams read "$FIRST_ID" --json
+else
+  printf '\nNo chat/channel id was discovered automatically.\n'
+  printf 'If listing succeeds manually, copy an id from `teams list --json` and run:\n'
+  printf '  %s teams read "<id>"\n' "$CLI"
+fi
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/packages/clawpilot-browser/src/__tests__/browser.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/browser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { BrowserManager } from '@clawpilot/browser/browser.js';
+import { BrowserManager, isTeamsAuthenticatedUrl } from '@clawpilot/browser/browser.js';
 
 describe('BrowserManager', () => {
   let tempDir: string | undefined;
@@ -52,5 +52,15 @@ describe('BrowserManager', () => {
   it('clearSession is safe on nonexistent dir', () => {
     const manager = new BrowserManager('/tmp/clawpilot-nonexistent-' + Date.now());
     expect(() => manager.clearSession()).not.toThrow();
+  });
+});
+
+describe('isTeamsAuthenticatedUrl', () => {
+  it('recognizes both legacy and cloud Teams app urls as authenticated destinations', () => {
+    expect(isTeamsAuthenticatedUrl('https://teams.microsoft.com/v2/')).toBe(true);
+    expect(isTeamsAuthenticatedUrl('https://teams.cloud.microsoft/')).toBe(true);
+    expect(
+      isTeamsAuthenticatedUrl('https://login.microsoftonline.com/common/oauth2/v2.0/authorize'),
+    ).toBe(false);
   });
 });

--- a/packages/clawpilot-browser/src/__tests__/teams-command.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams-command.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+const outputMock = vi.fn();
+const successMock = vi.fn((data?: unknown) => ({ ok: true as const, data }));
+const errorMock = vi.fn((type: string, message: string) => ({
+  ok: false as const,
+  error: type,
+  message,
+}));
+const listTeamsMock = vi.fn();
+const readTeamsMock = vi.fn();
+const formatTeamsListMock = vi.fn(() => 'formatted teams list');
+const formatTeamsReadMock = vi.fn(() => 'formatted teams read');
+const consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+vi.mock('@clawpilot/browser/utils/output.js', () => ({
+  output: outputMock,
+  success: successMock,
+  error: errorMock,
+}));
+
+vi.mock('@clawpilot/browser/teams.js', () => ({
+  listTeams: listTeamsMock,
+  readTeams: readTeamsMock,
+  formatTeamsList: formatTeamsListMock,
+  formatTeamsRead: formatTeamsReadMock,
+}));
+
+async function createProgram(): Promise<Command> {
+  const { registerTeamsCommands } = await import('@clawpilot/browser/commands/teams.js');
+  const program = new Command();
+  registerTeamsCommands(program);
+  return program;
+}
+
+describe('registerTeamsCommands', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    outputMock.mockClear();
+    successMock.mockClear();
+    errorMock.mockClear();
+    listTeamsMock.mockReset();
+    readTeamsMock.mockReset();
+    formatTeamsListMock.mockClear();
+    formatTeamsReadMock.mockClear();
+    consoleLogMock.mockClear();
+  });
+
+  it('prints JSON for teams list when requested', async () => {
+    listTeamsMock.mockResolvedValue({
+      page: { limit: 20, offset: 0, total: 1, hasMore: false, nextOffset: null },
+      chats: [],
+      channels: [],
+    });
+
+    const program = await createProgram();
+    await program.parseAsync(['node', 'test', 'teams', 'list', '--json']);
+
+    expect(listTeamsMock).toHaveBeenCalledWith({ limit: 20, offset: 0 });
+    expect(outputMock).toHaveBeenCalledWith({
+      ok: true,
+      data: {
+        page: { limit: 20, offset: 0, total: 1, hasMore: false, nextOffset: null },
+        chats: [],
+        channels: [],
+      },
+    });
+  });
+
+  it('prints human-readable output for teams read by default', async () => {
+    readTeamsMock.mockResolvedValue({
+      target: { id: '/l/chat/chat-1', kind: 'chat', title: 'Design Sync', path: 'Design Sync' },
+      page: { limit: 20, offset: 0, total: 1, hasMore: false, nextOffset: null },
+      messages: [{ id: 'm1', author: 'Alex', sentAt: null, text: 'Morning' }],
+    });
+
+    const program = await createProgram();
+    await program.parseAsync(['node', 'test', 'teams', 'read', '/l/chat/chat-1']);
+
+    expect(readTeamsMock).toHaveBeenCalledWith({ id: '/l/chat/chat-1', limit: 20, offset: 0 });
+    expect(formatTeamsReadMock).toHaveBeenCalled();
+    expect(consoleLogMock).toHaveBeenCalledWith('formatted teams read');
+  });
+});

--- a/packages/clawpilot-browser/src/__tests__/teams.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams.test.ts
@@ -13,6 +13,7 @@ import {
   formatTeamsList,
   formatTeamsRead,
   isTeamsAppOrigin,
+  mergeTeamsListCandidates,
   normalizeTeamsTargetId,
   parseTeamsChatListResponse,
   parseTeamsMessagesResponse,
@@ -31,7 +32,7 @@ describe('normalizeTeamsTargetId', () => {
         'https://teams.cloud.microsoft/l/chat/19%3Achat123%40thread.v2/0?tenantId=tenant-1',
       ),
     ).toEqual({
-      id: '/l/chat/19%3Achat123%40thread.v2/0?tenantId=tenant-1',
+      id: '/l/chat/19%3Achat123%40thread.v2',
       kind: 'chat',
     });
   });
@@ -161,6 +162,26 @@ describe('buildTeamsReadResult', () => {
     });
     expect(result.messages.map((message) => message.id)).toEqual(['m2', 'm3']);
   });
+
+  it('preserves the incoming message order instead of sorting lexicographically by id', () => {
+    const messages: TeamsMessage[] = [
+      { id: '10', author: 'Alex', sentAt: '2026-03-17T09:00:00.000Z', text: 'First' },
+      { id: '2', author: 'Sam', sentAt: '2026-03-17T09:05:00.000Z', text: 'Second' },
+    ];
+
+    const result = buildTeamsReadResult(
+      {
+        id: '/l/chat/chat-1',
+        kind: 'chat',
+        title: 'Design Sync',
+        path: 'Design Sync',
+      },
+      messages,
+      { limit: 20, offset: 0 },
+    );
+
+    expect(result.messages.map((message) => message.id)).toEqual(['10', '2']);
+  });
 });
 
 describe('formatTeamsRead', () => {
@@ -289,6 +310,48 @@ describe('extractTeamsTokensFromMsalCache', () => {
     };
     expect(extractTeamsTokensFromMsalCache(cache)).toBeNull();
   });
+
+  it('ignores expired tokens and prefers the newest cached matching entry', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const cache: Record<string, TeamsMsalCacheEntry> = {
+      expired: {
+        secret: 'expired-skype',
+        target: 'https://api.spaces.skype.com/.default',
+        expires_on: String(now - 10),
+        cached_at: String(now - 20),
+      },
+      olderCsa: {
+        secret: 'older-csa',
+        target: 'https://chatsvcagg.teams.microsoft.com/.default',
+        expires_on: String(now + 3600),
+        cached_at: String(now - 30),
+      },
+      newerCsa: {
+        secret: 'newer-csa',
+        target: 'https://chatsvcagg.teams.microsoft.com/.default',
+        expires_on: String(now + 7200),
+        cached_at: String(now - 5),
+      },
+      skype: {
+        secret: 'fresh-skype',
+        target: 'https://api.spaces.skype.com/.default',
+        expires_on: String(now + 3600),
+        cached_at: String(now - 5),
+      },
+      chatSvc: {
+        secret: 'fresh-ic3',
+        target: 'https://ic3.teams.office.com/.default',
+        expires_on: String(now + 3600),
+        cached_at: String(now - 5),
+      },
+    };
+
+    expect(extractTeamsTokensFromMsalCache(cache)).toEqual({
+      skype: 'fresh-skype',
+      chatSvcAgg: 'newer-csa',
+      chatSvc: 'fresh-ic3',
+    });
+  });
 });
 
 describe('parseTeamsChatListResponse', () => {
@@ -328,11 +391,50 @@ describe('parseTeamsChatListResponse', () => {
     const [first, second] = items;
     expect(first).toBeDefined();
     expect(second).toBeDefined();
-    expect(first?.id).toBe('19:abc@thread.v2');
+    expect(first?.id).toBe('/l/chat/19%3Aabc%40thread.v2');
+    expect(first?.path).toBe('/l/chat/19%3Aabc%40thread.v2');
     expect(first?.title).toBe('Design Sync');
     expect(first?.kind).toBe('chat');
     expect(first?.preview).toBe('See you tomorrow');
     expect(second?.title).toContain('user1');
+  });
+});
+
+describe('mergeTeamsListCandidates', () => {
+  it('keeps direct chat results and appends missing DOM channels without duplicates', () => {
+    const merged = mergeTeamsListCandidates(
+      [
+        {
+          id: '/l/chat/19%3Achat1%40thread.v2',
+          kind: 'chat',
+          title: 'Project Alpha',
+          path: '/l/chat/19%3Achat1%40thread.v2',
+          preview: 'Latest update',
+          order: 0,
+        },
+      ],
+      [
+        {
+          id: '/l/chat/19%3Achat1%40thread.v2',
+          kind: 'chat',
+          title: 'Project Alpha',
+          path: '/l/chat/19%3Achat1%40thread.v2',
+          preview: 'Latest update',
+          order: 3,
+        },
+        {
+          id: '/l/channel/19%3Achannel1%40thread.tacv2/General?groupId=team-1',
+          kind: 'channel',
+          title: 'General',
+          path: 'Engineering / General',
+          preview: 'Build is green',
+          order: 4,
+        },
+      ],
+    );
+
+    expect(merged.map((item) => item.kind)).toEqual(['chat', 'channel']);
+    expect(merged[1]?.order).toBe(1);
   });
 });
 
@@ -389,6 +491,23 @@ describe('settleTeamsAsyncAction', () => {
         () => 'timed_out',
       ),
     ).resolves.toBe('timed_out');
+  });
+
+  it('clears the timeout when the action settles first', async () => {
+    vi.useFakeTimers();
+    try {
+      const resultPromise = settleTeamsAsyncAction(
+        async () => 'ready',
+        10_000,
+        () => 'timed_out',
+      );
+      await Promise.resolve();
+
+      expect(await resultPromise).toBe('ready');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -591,13 +710,18 @@ describe('readTeamsDirect', () => {
     const { readTeamsDirect } = await import('@clawpilot/browser/teams.js');
     const result = await readTeamsDirect(
       stubTokens,
-      { id: '19:chat1@thread.v2', limit: 50, offset: 0 },
+      { id: '/l/chat/19%3Achat1%40thread.v2', limit: 50, offset: 0 },
       mockFetch,
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/conversations/19%3Achat1%40thread.v2/messages'),
+      expect.any(Object),
+    );
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]?.text).toBe('Hello team');
-    expect(result.target.id).toBe('19:chat1@thread.v2');
+    expect(result.target.id).toBe('/l/chat/19%3Achat1%40thread.v2');
   });
 });

--- a/packages/clawpilot-browser/src/__tests__/teams.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams.test.ts
@@ -1,0 +1,585 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildTeamsListResult,
+  buildTeamsReadResult,
+  classifyTeamsAuthProbeStatus,
+  extractTeamsTokensFromMsalCache,
+  fetchTeamsAuthzBootstrap,
+  fetchTeamsChatList,
+  fetchTeamsMessages,
+  formatTeamsAuthTimeoutMessage,
+  detectTeamsShellError,
+  formatTeamsShellErrorMessage,
+  formatTeamsList,
+  formatTeamsRead,
+  normalizeTeamsTargetId,
+  parseTeamsChatListResponse,
+  parseTeamsMessagesResponse,
+  settleTeamsAsyncAction,
+  settleTeamsInteractiveLoginTrigger,
+  type TeamsListCandidate,
+  type TeamsMessage,
+  type TeamsMsalCacheEntry,
+  type TeamsTokenSet,
+} from '@clawpilot/browser/teams.js';
+
+describe('normalizeTeamsTargetId', () => {
+  it('normalizes chat hrefs to stable relative ids', () => {
+    expect(
+      normalizeTeamsTargetId(
+        'https://teams.cloud.microsoft/l/chat/19%3Achat123%40thread.v2/0?tenantId=tenant-1',
+      ),
+    ).toEqual({
+      id: '/l/chat/19%3Achat123%40thread.v2/0?tenantId=tenant-1',
+      kind: 'chat',
+    });
+  });
+
+  it('normalizes channel hrefs to stable relative ids', () => {
+    expect(
+      normalizeTeamsTargetId(
+        'https://teams.cloud.microsoft/l/channel/19%3Achannel456%40thread.tacv2/General?groupId=team-9&tenantId=tenant-1',
+      ),
+    ).toEqual({
+      id: '/l/channel/19%3Achannel456%40thread.tacv2/General?groupId=team-9&tenantId=tenant-1',
+      kind: 'channel',
+    });
+  });
+});
+
+describe('buildTeamsListResult', () => {
+  it('paginates combined chat and channel results while keeping sections separate', () => {
+    const items: TeamsListCandidate[] = [
+      {
+        id: '/l/chat/chat-1',
+        kind: 'chat',
+        title: 'Design Sync',
+        path: 'Design Sync',
+        preview: 'See you tomorrow',
+        order: 0,
+      },
+      {
+        id: '/l/channel/channel-1/General?groupId=team-1',
+        kind: 'channel',
+        title: 'General',
+        path: 'Engineering / General',
+        preview: 'Build is green',
+        order: 1,
+      },
+      {
+        id: '/l/chat/chat-2',
+        kind: 'chat',
+        title: 'Release Crew',
+        path: 'Release Crew',
+        preview: 'Ship it',
+        order: 2,
+      },
+    ];
+
+    const result = buildTeamsListResult(items, { limit: 2, offset: 1 });
+
+    expect(result.page).toEqual({
+      hasMore: false,
+      limit: 2,
+      nextOffset: null,
+      offset: 1,
+      total: 3,
+    });
+    expect(result.chats.map((item) => item.title)).toEqual(['Release Crew']);
+    expect(result.channels.map((item) => item.path)).toEqual(['Engineering / General']);
+  });
+});
+
+describe('formatTeamsList', () => {
+  it('renders human-readable chat and channel sections with pagination info', () => {
+    const result = buildTeamsListResult(
+      [
+        {
+          id: '/l/chat/chat-1',
+          kind: 'chat',
+          title: 'Design Sync',
+          path: 'Design Sync',
+          preview: 'See you tomorrow',
+          order: 0,
+        },
+        {
+          id: '/l/channel/channel-1/General?groupId=team-1',
+          kind: 'channel',
+          title: 'General',
+          path: 'Engineering / General',
+          preview: 'Build is green',
+          order: 1,
+        },
+      ],
+      { limit: 20, offset: 0 },
+    );
+
+    expect(formatTeamsList(result)).toContain(
+      'Teams conversations (2 total, showing 2, offset 0, limit 20)',
+    );
+    expect(formatTeamsList(result)).toContain('Chats');
+    expect(formatTeamsList(result)).toContain('Channels');
+    expect(formatTeamsList(result)).toContain('Preview: See you tomorrow');
+    expect(formatTeamsList(result)).toContain('Engineering / General');
+  });
+});
+
+describe('buildTeamsReadResult', () => {
+  it('paginates messages for a selected thread', () => {
+    const messages: TeamsMessage[] = [
+      { id: 'm1', author: 'Alex', sentAt: '2026-03-17T09:00:00.000Z', text: 'Morning' },
+      { id: 'm2', author: 'Sam', sentAt: '2026-03-17T09:05:00.000Z', text: 'Status?' },
+      { id: 'm3', author: 'Alex', sentAt: '2026-03-17T09:06:00.000Z', text: 'Almost done' },
+    ];
+
+    const result = buildTeamsReadResult(
+      {
+        id: '/l/chat/chat-1',
+        kind: 'chat',
+        title: 'Design Sync',
+        path: 'Design Sync',
+      },
+      messages,
+      { limit: 2, offset: 1 },
+    );
+
+    expect(result.page).toEqual({
+      hasMore: false,
+      limit: 2,
+      nextOffset: null,
+      offset: 1,
+      total: 3,
+    });
+    expect(result.messages.map((message) => message.id)).toEqual(['m2', 'm3']);
+  });
+});
+
+describe('formatTeamsRead', () => {
+  it('renders the selected target and its messages', () => {
+    const rendered = formatTeamsRead(
+      buildTeamsReadResult(
+        {
+          id: '/l/chat/chat-1',
+          kind: 'chat',
+          title: 'Design Sync',
+          path: 'Design Sync',
+        },
+        [{ id: 'm1', author: 'Alex', sentAt: '2026-03-17T09:00:00.000Z', text: 'Morning' }],
+        { limit: 20, offset: 0 },
+      ),
+    );
+
+    expect(rendered).toContain('Design Sync');
+    expect(rendered).toContain('Messages (1)');
+    expect(rendered).toContain('Alex');
+    expect(rendered).toContain('Morning');
+  });
+});
+
+describe('detectTeamsShellError', () => {
+  it('detects the Teams retry shell and surfaces its message', () => {
+    expect(
+      detectTeamsShellError({
+        bodyText: 'Oops\nOops, unknown error!\nRetry\nClear cache and retry',
+        buttonTexts: ['Retry', 'Clear cache and retry'],
+      }),
+    ).toBe(
+      'Teams web client reached its retry screen ("Oops, unknown error!"). Open Teams manually and let it finish loading, then retry.',
+    );
+  });
+});
+
+describe('formatTeamsShellErrorMessage', () => {
+  it('includes the auto-wait timeout when Teams never recovers', () => {
+    expect(formatTeamsShellErrorMessage('Oops, unknown error!', 60)).toBe(
+      'Teams web client stayed on its retry screen for 60 seconds ("Oops, unknown error!"). Open Teams manually and let it finish loading, then retry.',
+    );
+  });
+});
+
+describe('classifyTeamsAuthProbeStatus', () => {
+  it('treats 200 responses as authenticated', () => {
+    expect(classifyTeamsAuthProbeStatus(200)).toBe('authenticated');
+  });
+
+  it('treats 401 responses as interactive auth required', () => {
+    expect(classifyTeamsAuthProbeStatus(401)).toBe('interactive_auth_required');
+  });
+
+  it('treats unexpected responses as probe failures', () => {
+    expect(classifyTeamsAuthProbeStatus(503)).toBe('probe_failed');
+  });
+});
+
+describe('formatTeamsAuthTimeoutMessage', () => {
+  it('explains that Teams sign-in did not become ready in time', () => {
+    expect(formatTeamsAuthTimeoutMessage(120)).toBe(
+      'Teams needs an interactive sign-in before chats or channels can be read. A Teams window was opened and waited for 120 seconds, but auth never became ready. Finish signing in there, then retry.',
+    );
+  });
+});
+
+describe('settleTeamsInteractiveLoginTrigger', () => {
+  it('returns triggered when the login handoff resolves promptly', async () => {
+    await expect(settleTeamsInteractiveLoginTrigger(async () => undefined, 10)).resolves.toBe(
+      'triggered',
+    );
+  });
+
+  it('returns timed_out when the login handoff never settles', async () => {
+    await expect(
+      settleTeamsInteractiveLoginTrigger(async () => new Promise<void>(() => undefined), 10),
+    ).resolves.toBe('timed_out');
+  });
+});
+
+describe('extractTeamsTokensFromMsalCache', () => {
+  const makeCacheEntry = (audience: string, secret: string): TeamsMsalCacheEntry => ({
+    secret,
+    target: `${audience}/user_impersonation ${audience}/.default`,
+    expires_on: String(Math.floor(Date.now() / 1000) + 3600),
+    cached_at: String(Math.floor(Date.now() / 1000)),
+  });
+
+  it('extracts all three audience tokens from an MSAL localStorage dump', () => {
+    const cache: Record<string, TeamsMsalCacheEntry> = {
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-skype': makeCacheEntry(
+        'https://api.spaces.skype.com',
+        'skype-token-abc',
+      ),
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-csa': makeCacheEntry(
+        'https://chatsvcagg.teams.microsoft.com',
+        'csa-token-def',
+      ),
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-ic3': makeCacheEntry(
+        'https://ic3.teams.office.com',
+        'ic3-token-ghi',
+      ),
+    };
+
+    const result = extractTeamsTokensFromMsalCache(cache);
+    expect(result).toEqual({
+      skype: 'skype-token-abc',
+      chatSvcAgg: 'csa-token-def',
+      chatSvc: 'ic3-token-ghi',
+    });
+  });
+
+  it('returns null when a required audience token is missing', () => {
+    const cache: Record<string, TeamsMsalCacheEntry> = {
+      'some-key': makeCacheEntry('https://api.spaces.skype.com', 'skype-only'),
+    };
+    expect(extractTeamsTokensFromMsalCache(cache)).toBeNull();
+  });
+});
+
+describe('parseTeamsChatListResponse', () => {
+  it('normalizes raw CSA groupchats response into TeamsListCandidate items', () => {
+    const raw = [
+      {
+        id: '19:abc@thread.v2',
+        title: 'Design Sync',
+        chatType: 'chat',
+        lastMessage: {
+          content: '<p>See you tomorrow</p>',
+          imdisplayname: 'Alex',
+          composetime: '2026-03-18T09:00:00Z',
+        },
+        hidden: false,
+      },
+      {
+        id: '19:def@thread.v2',
+        title: null,
+        chatType: 'chat',
+        lastMessage: {
+          content: 'Hello',
+          imdisplayname: 'Sam',
+          composetime: '2026-03-17T08:00:00Z',
+        },
+        members: [
+          { isMuted: false, mri: '8:orgid:user1', objectId: 'user1', role: 'Admin' },
+          { isMuted: false, mri: '8:orgid:user2', objectId: 'user2', role: 'Admin' },
+        ],
+        hidden: false,
+      },
+    ];
+
+    const items = parseTeamsChatListResponse(raw);
+    expect(items).toHaveLength(2);
+
+    const [first, second] = items;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first?.id).toBe('19:abc@thread.v2');
+    expect(first?.title).toBe('Design Sync');
+    expect(first?.kind).toBe('chat');
+    expect(first?.preview).toBe('See you tomorrow');
+    expect(second?.title).toContain('user1');
+  });
+});
+
+describe('parseTeamsMessagesResponse', () => {
+  it('normalizes raw chatsvc messages into TeamsMessage items', () => {
+    const raw = {
+      messages: [
+        {
+          id: '111',
+          imdisplayname: 'Alex',
+          composetime: '2026-03-18T09:00:00Z',
+          content: '<p>Morning</p>',
+          messagetype: 'RichText/Html',
+          type: 'Message',
+        },
+        {
+          id: '222',
+          imdisplayname: '',
+          composetime: '2026-03-18T09:01:00Z',
+          content: '',
+          messagetype: 'ThreadActivity/TopicUpdate',
+          type: 'Message',
+        },
+      ],
+    };
+
+    const messages = parseTeamsMessagesResponse(raw);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({
+      id: '111',
+      author: 'Alex',
+      sentAt: '2026-03-18T09:00:00Z',
+      text: 'Morning',
+    });
+  });
+});
+
+describe('settleTeamsAsyncAction', () => {
+  it('returns the action result when it settles before the timeout', async () => {
+    await expect(
+      settleTeamsAsyncAction(
+        async () => 'ready',
+        10,
+        () => 'timed_out',
+      ),
+    ).resolves.toBe('ready');
+  });
+
+  it('returns the timeout fallback when the action never settles', async () => {
+    await expect(
+      settleTeamsAsyncAction(
+        async () => new Promise<string>(() => undefined),
+        10,
+        () => 'timed_out',
+      ),
+    ).resolves.toBe('timed_out');
+  });
+});
+
+// --- Direct HTTP client tests (fetch mocked) ---
+
+const stubTokens: TeamsTokenSet = {
+  skype: 'skype-bearer',
+  chatSvcAgg: 'csa-bearer',
+  chatSvc: 'ic3-bearer',
+};
+
+describe('fetchTeamsAuthzBootstrap', () => {
+  it('posts to authz and returns region + skypeToken from the response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        regionGtms: { middleTier: 'https://teams.microsoft.com' },
+        region: 'uk',
+        partition: 'uk02',
+        tokens: { skypeToken: 'skype-token-from-authz' },
+      }),
+    });
+
+    const result = await fetchTeamsAuthzBootstrap(stubTokens.skype, mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://teams.microsoft.com/api/authsvc/v1.0/authz',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer skype-bearer',
+        }),
+      }),
+    );
+    expect(result.region).toBe('uk');
+    expect(result.partition).toBe('uk02');
+    expect(result.skypeToken).toBe('skype-token-from-authz');
+  });
+
+  it('throws on non-OK response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    await expect(fetchTeamsAuthzBootstrap(stubTokens.skype, mockFetch)).rejects.toThrow(
+      /authz.*401/i,
+    );
+  });
+});
+
+describe('fetchTeamsChatList', () => {
+  it('fetches groupchats with correct auth and region headers', async () => {
+    const chatPayload = [{ id: '19:abc@thread.v2', title: 'Chat A', chatType: 'chat' }];
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => chatPayload,
+    });
+
+    const result = await fetchTeamsChatList(
+      { token: stubTokens.chatSvcAgg, region: 'uk', partition: 'uk02' },
+      mockFetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/csa/uk/api/v1/teams/users/me/groupchats'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer csa-bearer',
+          'x-ms-region': 'uk',
+          'x-ms-partition': 'uk02',
+        }),
+      }),
+    );
+    expect(result).toEqual(chatPayload);
+  });
+});
+
+describe('fetchTeamsMessages', () => {
+  it('fetches messages for a conversation with correct headers', async () => {
+    const messagesPayload = {
+      messages: [
+        {
+          id: '1',
+          imdisplayname: 'Bob',
+          composetime: '2026-01-01T00:00:00Z',
+          content: 'Hello',
+          messagetype: 'Text',
+          type: 'Message',
+        },
+      ],
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => messagesPayload,
+    });
+
+    const result = await fetchTeamsMessages(
+      {
+        token: stubTokens.chatSvc,
+        region: 'uk',
+        partition: 'uk02',
+        conversationId: '19:abc@thread.v2',
+        pageSize: 50,
+      },
+      mockFetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/api/chatsvc/uk/v1/users/ME/conversations/19%3Aabc%40thread.v2/messages',
+      ),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer ic3-bearer',
+        }),
+      }),
+    );
+    expect(result).toEqual(messagesPayload);
+  });
+});
+
+describe('listTeamsDirect', () => {
+  it('fetches authz bootstrap, then chat list, and returns a TeamsListResult', async () => {
+    const authzResponse = {
+      ok: true,
+      json: async (): Promise<unknown> => ({
+        region: 'uk',
+        partition: 'uk02',
+        tokens: { skypeToken: 'skype-realtime' },
+        regionGtms: {},
+      }),
+    };
+    const chatListResponse = {
+      ok: true,
+      json: async (): Promise<unknown> => [
+        {
+          id: '19:chat1@thread.v2',
+          title: 'Project Alpha',
+          chatType: 'chat',
+          lastMessage: { content: 'Latest update', imdisplayname: 'Jo' },
+        },
+        {
+          id: '19:chat2@thread.v2',
+          title: 'Standup',
+          chatType: 'chat',
+          lastMessage: { content: 'Done for today', imdisplayname: 'Alex' },
+        },
+      ],
+    };
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(authzResponse)
+      .mockResolvedValueOnce(chatListResponse);
+
+    const { listTeamsDirect } = await import('@clawpilot/browser/teams.js');
+    const result = await listTeamsDirect(stubTokens, { limit: 20, offset: 0 }, mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.chats).toHaveLength(2);
+    expect(result.chats[0]?.title).toBe('Project Alpha');
+    expect(result.page.total).toBe(2);
+  });
+});
+
+describe('readTeamsDirect', () => {
+  it('fetches authz bootstrap, then messages, and returns a TeamsReadResult', async () => {
+    const authzResponse = {
+      ok: true,
+      json: async (): Promise<unknown> => ({
+        region: 'uk',
+        partition: 'uk02',
+        tokens: { skypeToken: 'skype-realtime' },
+        regionGtms: {},
+      }),
+    };
+    const messagesResponse = {
+      ok: true,
+      json: async (): Promise<unknown> => ({
+        messages: [
+          {
+            id: '1',
+            imdisplayname: 'Jo',
+            composetime: '2026-03-18T10:00:00Z',
+            content: '<p>Hello team</p>',
+            messagetype: 'RichText/Html',
+            type: 'Message',
+          },
+        ],
+      }),
+    };
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(authzResponse)
+      .mockResolvedValueOnce(messagesResponse);
+
+    const { readTeamsDirect } = await import('@clawpilot/browser/teams.js');
+    const result = await readTeamsDirect(
+      stubTokens,
+      { id: '19:chat1@thread.v2', limit: 50, offset: 0 },
+      mockFetch,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.text).toBe('Hello team');
+    expect(result.target.id).toBe('19:chat1@thread.v2');
+  });
+});

--- a/packages/clawpilot-browser/src/__tests__/teams.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams.test.ts
@@ -12,6 +12,7 @@ import {
   formatTeamsShellErrorMessage,
   formatTeamsList,
   formatTeamsRead,
+  isTeamsAppOrigin,
   normalizeTeamsTargetId,
   parseTeamsChatListResponse,
   parseTeamsMessagesResponse,
@@ -44,6 +45,14 @@ describe('normalizeTeamsTargetId', () => {
       id: '/l/channel/19%3Achannel456%40thread.tacv2/General?groupId=team-9&tenantId=tenant-1',
       kind: 'channel',
     });
+  });
+});
+
+describe('isTeamsAppOrigin', () => {
+  it('treats both teams.microsoft.com and teams.cloud.microsoft as authenticated Teams app origins', () => {
+    expect(isTeamsAppOrigin('https://teams.microsoft.com')).toBe(true);
+    expect(isTeamsAppOrigin('https://teams.cloud.microsoft')).toBe(true);
+    expect(isTeamsAppOrigin('https://login.microsoftonline.com')).toBe(false);
   });
 });
 
@@ -186,6 +195,15 @@ describe('detectTeamsShellError', () => {
     ).toBe(
       'Teams web client reached its retry screen ("Oops, unknown error!"). Open Teams manually and let it finish loading, then retry.',
     );
+  });
+
+  it('ignores incidental Retry buttons when the Teams shell otherwise looks healthy', () => {
+    expect(
+      detectTeamsShellError({
+        bodyText: 'Chat\nCalendar\nCalls\nPlanner\nTeams and channels',
+        buttonTexts: ['Retry', 'Clear cache and retry'],
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/clawpilot-browser/src/browser.ts
+++ b/packages/clawpilot-browser/src/browser.ts
@@ -24,6 +24,7 @@ const TEAMS_AUTHENTICATED_PATTERNS = [
   /teams\.microsoft\.com\/_#/,
   /teams\.microsoft\.com\/v2/,
   /teams\.microsoft\.com\/\?/,
+  /teams\.cloud\.microsoft\//,
 ];
 
 /** URL patterns that indicate a login page (session expired) */
@@ -39,6 +40,10 @@ type SessionValidationSummary = SessionMetadataSummary & {
   lastValidatedAt: string | null;
   lastValidatedResult: SessionValidationResult | null;
 };
+
+export function isTeamsAuthenticatedUrl(url: string): boolean {
+  return TEAMS_AUTHENTICATED_PATTERNS.some((pattern) => pattern.test(url));
+}
 
 export class BrowserManager {
   readonly stateDir: string;
@@ -82,7 +87,7 @@ export class BrowserManager {
     try {
       const page = context.pages()[0] || (await context.newPage());
       await page.goto('https://teams.microsoft.com');
-      await page.waitForURL((url) => TEAMS_AUTHENTICATED_PATTERNS.some((p) => p.test(url.href)), {
+      await page.waitForURL((url) => isTeamsAuthenticatedUrl(url.href), {
         timeout: LOGIN_TIMEOUT_MS,
       });
       const existingMetadata = readSessionMetadata(this.stateDir);

--- a/packages/clawpilot-browser/src/commands/teams.ts
+++ b/packages/clawpilot-browser/src/commands/teams.ts
@@ -1,0 +1,94 @@
+import type { Command } from 'commander';
+import { error, output, success } from '@clawpilot/browser/utils/output.js';
+import {
+  formatTeamsList,
+  formatTeamsRead,
+  listTeams,
+  readTeams,
+} from '@clawpilot/browser/teams.js';
+
+interface TeamsCommandOptions {
+  limit: string;
+  offset: string;
+  json: boolean;
+}
+
+export function registerTeamsCommands(program: Command): void {
+  const teams = program
+    .command('teams')
+    .description('List and read Microsoft Teams chats and channels');
+
+  teams
+    .command('list')
+    .description('List chats and channels from Teams')
+    .option('--limit <n>', 'Maximum number of items to return', '20')
+    .option('--offset <n>', 'Number of items to skip before listing', '0')
+    .option('--json', 'Return structured JSON output', false)
+    .action(async (options: TeamsCommandOptions): Promise<void> => {
+      const pagination = parsePagination(options);
+      if (!pagination.ok) {
+        output(error('invalid_pagination', pagination.message));
+        return;
+      }
+
+      try {
+        const result = await listTeams(pagination.value);
+        if (options.json) {
+          output(success(result));
+          return;
+        }
+
+        console.log(formatTeamsList(result));
+      } catch (err) {
+        output(
+          error('teams_list_failed', err instanceof Error ? err.message : 'Teams list failed'),
+        );
+      }
+    });
+
+  teams
+    .command('read')
+    .description('Read messages from a chat or channel by id')
+    .argument('<id>')
+    .option('--limit <n>', 'Maximum number of messages to return', '20')
+    .option('--offset <n>', 'Number of messages to skip before reading', '0')
+    .option('--json', 'Return structured JSON output', false)
+    .action(async (id: string, options: TeamsCommandOptions): Promise<void> => {
+      const pagination = parsePagination(options);
+      if (!pagination.ok) {
+        output(error('invalid_pagination', pagination.message));
+        return;
+      }
+
+      try {
+        const result = await readTeams({ id, ...pagination.value });
+        if (options.json) {
+          output(success(result));
+          return;
+        }
+
+        console.log(formatTeamsRead(result));
+      } catch (err) {
+        output(
+          error('teams_read_failed', err instanceof Error ? err.message : 'Teams read failed'),
+        );
+      }
+    });
+}
+
+function parsePagination(
+  options: TeamsCommandOptions,
+): { ok: true; value: { limit: number; offset: number } } | { ok: false; message: string } {
+  const limit = Number.parseInt(options.limit, 10);
+  const offset = Number.parseInt(options.offset, 10);
+
+  if (Number.isNaN(limit) || limit <= 0) {
+    return { ok: false, message: 'limit must be a positive integer' };
+  }
+
+  if (Number.isNaN(offset) || offset < 0) {
+    return { ok: false, message: 'offset must be a non-negative integer' };
+  }
+
+  return { ok: true, value: { limit, offset } };
+}

--- a/packages/clawpilot-browser/src/index.ts
+++ b/packages/clawpilot-browser/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import { registerAuthCommands } from '@clawpilot/browser/commands/auth.js';
 import { registerHealthCommands } from '@clawpilot/browser/commands/health.js';
+import { registerTeamsCommands } from '@clawpilot/browser/commands/teams.js';
 import { registerWebCommands } from '@clawpilot/browser/commands/web.js';
 
 const program = new Command();
@@ -14,6 +15,7 @@ program
 
 registerHealthCommands(program);
 registerAuthCommands(program);
+registerTeamsCommands(program);
 registerWebCommands(program);
 
 program.parse();

--- a/packages/clawpilot-browser/src/teams.ts
+++ b/packages/clawpilot-browser/src/teams.ts
@@ -17,11 +17,12 @@ const LOAD_TIMEOUT_MS = 30_000;
 const RENDER_WAIT_MS = 10_000;
 const TEAMS_RECOVERY_TIMEOUT_MS = 60_000;
 const TEAMS_RECOVERY_POLL_INTERVAL_MS = 5_000;
-const TEAMS_AUTH_TIMEOUT_MS = 120_000;
+const TEAMS_AUTH_TIMEOUT_MS = 300_000;
 const TEAMS_AUTH_POLL_INTERVAL_MS = 2_000;
 const TEAMS_AUTH_PROBE_TIMEOUT_MS = 5_000;
 const TEAMS_LOGIN_TRIGGER_TIMEOUT_MS = 5_000;
 const TEAMS_CONTEXT_CLOSE_TIMEOUT_MS = 5_000;
+const TEAMS_PAGE_UNLOAD_TIMEOUT_MS = 2_000;
 
 export type TeamsAuthProbeStatus = 'authenticated' | 'interactive_auth_required' | 'probe_failed';
 export type TeamsInteractiveLoginTriggerStatus = 'triggered' | 'timed_out';
@@ -128,9 +129,13 @@ export interface TeamsTokenSet {
   chatSvc: string;
 }
 
+export function isTeamsAppOrigin(origin: string): boolean {
+  return origin === 'https://teams.microsoft.com' || origin === TEAMS_BASE_URL;
+}
+
 export function normalizeTeamsTargetId(href: string): { id: string; kind: TeamsItemKind } | null {
   const url = new URL(href, TEAMS_BASE_URL);
-  const isTeamsOrigin = [TEAMS_BASE_URL, 'https://teams.microsoft.com'].includes(url.origin);
+  const isTeamsOrigin = isTeamsAppOrigin(url.origin);
 
   if (!isTeamsOrigin) {
     return null;
@@ -264,8 +269,16 @@ export function formatTeamsRead(result: TeamsReadResult): string {
 
 export function detectTeamsShellError(snapshot: TeamsShellSnapshot): string | null {
   const normalizedButtons = snapshot.buttonTexts.map((button) => button.trim().toLowerCase());
+  const normalizedBody = snapshot.bodyText.trim().toLowerCase();
 
-  if (!normalizedButtons.includes('retry')) {
+  const hasRetryUi =
+    normalizedButtons.includes('retry') && normalizedButtons.includes('clear cache and retry');
+  const looksLikeRetryShell =
+    normalizedBody.includes('oops') ||
+    normalizedBody.includes('unknown error') ||
+    normalizedBody.includes('something went wrong');
+
+  if (!hasRetryUi || !looksLikeRetryShell) {
     return null;
   }
 
@@ -353,15 +366,44 @@ function stripHtml(html: string): string {
 }
 
 export function parseTeamsChatListResponse(
-  raw: Array<{
-    id: string;
-    title: string | null;
-    chatType: string;
-    lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
-    members?: Array<{ objectId: string }>;
-    hidden?: boolean;
-  }>,
+  raw:
+    | {
+        conversations: Array<{
+          id: string;
+          type: string;
+          threadProperties?: { topic?: string; threadType?: string };
+          lastMessage?: { composetime?: string; imdisplayname?: string; content?: string };
+        }>;
+      }
+    | Array<{
+        id: string;
+        title: string | null;
+        chatType: string;
+        lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
+        members?: Array<{ objectId: string }>;
+        hidden?: boolean;
+      }>,
 ): TeamsListCandidate[] {
+  // Handle chatsvc conversations format
+  if ('conversations' in raw) {
+    return raw.conversations
+      .filter(
+        (c) =>
+          !c.id.includes('notifications') &&
+          !c.id.includes('unq.gbl.spaces') &&
+          c.type === 'Conversation',
+      )
+      .map((c, i) => ({
+        id: c.id,
+        kind: (c.threadProperties?.threadType === 'channel' ? 'channel' : 'chat') as TeamsItemKind,
+        title: c.threadProperties?.topic ?? c.id,
+        path: `/l/chat/${encodeURIComponent(c.id)}`,
+        preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
+        order: i,
+      }));
+  }
+
+  // Handle legacy CSA groupchats format
   return raw
     .filter((c) => !c.hidden)
     .map((c, i) => ({
@@ -499,14 +541,7 @@ export async function listTeamsDirect(
   const raw = (await fetchTeamsChatList(
     { token: tokens.chatSvcAgg, region: authz.region, partition: authz.partition },
     fetchImpl,
-  )) as Array<{
-    id: string;
-    title: string | null;
-    chatType: string;
-    lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
-    members?: Array<{ objectId: string }>;
-    hidden?: boolean;
-  }>;
+  )) as Parameters<typeof parseTeamsChatListResponse>[0];
   const items = parseTeamsChatListResponse(raw);
   return buildTeamsListResult(items, options);
 }
@@ -578,10 +613,6 @@ export async function listTeams(options: TeamsListOptions): Promise<TeamsListRes
     await loadTeamsShell(page);
     await ensureTeamsAuthReady(page);
     await makeWindowUnobtrusive(page);
-    const shellError = await getTeamsShellError(page);
-    if (shellError) {
-      throw new Error(shellError);
-    }
 
     // Try direct HTTP first (faster, more reliable)
     const tokens = await extractTeamsTokensFromPage(page);
@@ -591,6 +622,11 @@ export async function listTeams(options: TeamsListOptions): Promise<TeamsListRes
       } catch {
         // Fall back to DOM scraping
       }
+    }
+
+    const shellError = await getTeamsShellError(page);
+    if (shellError) {
+      throw new Error(shellError);
     }
 
     const items = normalizeTeamsListNodes(await collectTeamsListNodes(page));
@@ -609,12 +645,8 @@ export async function readTeams(options: TeamsReadOptions): Promise<TeamsReadRes
     await loadTeamsShell(page);
     await ensureTeamsAuthReady(page);
     await makeWindowUnobtrusive(page);
-    const shellError = await getTeamsShellError(page);
-    if (shellError) {
-      throw new Error(shellError);
-    }
 
-    // Try direct HTTP first (faster, more reliable)
+    // Try direct HTTP first (faster, doesn't need shell loaded)
     const tokens = await extractTeamsTokensFromPage(page);
     if (tokens) {
       try {
@@ -624,6 +656,11 @@ export async function readTeams(options: TeamsReadOptions): Promise<TeamsReadRes
       }
     }
 
+    // DOM scraping fallback — needs shell fully loaded
+    const shellError = await getTeamsShellError(page);
+    if (shellError) {
+      throw new Error(shellError);
+    }
     await page.goto(resolveTeamsTargetUrl(options.id), {
       timeout: LOAD_TIMEOUT_MS,
       waitUntil: 'domcontentloaded',
@@ -659,15 +696,29 @@ async function withTeamsPage<T>(run: (page: Page) => Promise<T>): Promise<T> {
   let context: BrowserContext | undefined;
 
   try {
-    context = await chromium.launchPersistentContext(DEFAULT_STATE_DIR, {
-      ...createBackgroundWindowLaunchOptions(),
-    });
+    context = await chromium.launchPersistentContext(
+      DEFAULT_STATE_DIR,
+      createBackgroundWindowLaunchOptions(),
+    );
     const page = context.pages()[0] ?? (await context.newPage());
     await makeWindowUnobtrusive(page);
     return await run(page);
   } finally {
     if (context) {
       const contextToClose = context;
+      await Promise.all(
+        contextToClose.pages().map(async (page) => {
+          await settleTeamsAsyncAction(
+            () =>
+              page.goto('about:blank', {
+                timeout: TEAMS_PAGE_UNLOAD_TIMEOUT_MS,
+                waitUntil: 'domcontentloaded',
+              }),
+            TEAMS_PAGE_UNLOAD_TIMEOUT_MS + 1_000,
+            () => undefined,
+          );
+        }),
+      );
       await settleTeamsAsyncAction(
         () => contextToClose.close(),
         TEAMS_CONTEXT_CLOSE_TIMEOUT_MS,
@@ -701,13 +752,7 @@ async function maybeRetryShell(page: Page): Promise<void> {
 }
 
 async function isRetryShell(page: Page): Promise<boolean> {
-  const buttons = await page.evaluate(() =>
-    Array.from(document.querySelectorAll('button')).map((button) =>
-      (button.textContent ?? '').trim().toLowerCase(),
-    ),
-  );
-
-  return buttons.includes('retry');
+  return (await getTeamsShellError(page)) !== null;
 }
 
 async function getTeamsShellError(page: Page): Promise<string | null> {
@@ -771,7 +816,7 @@ async function waitForTeamsRecovery(page: Page): Promise<void> {
 }
 
 async function ensureTeamsAuthReady(page: Page): Promise<void> {
-  if (new URL(page.url()).origin !== 'https://teams.microsoft.com') {
+  if (!isTeamsAppOrigin(new URL(page.url()).origin)) {
     await page.goto(FALLBACK_TEAMS_URL, {
       timeout: LOAD_TIMEOUT_MS,
       waitUntil: 'domcontentloaded',
@@ -785,6 +830,11 @@ async function ensureTeamsAuthReady(page: Page): Promise<void> {
 
   while (true) {
     const probe = await probeTeamsAuth(page);
+
+    if (probe.status === null && probe.pageOrigin === TEAMS_BASE_URL) {
+      return;
+    }
+
     const status =
       probe.status === null
         ? 'interactive_auth_required'

--- a/packages/clawpilot-browser/src/teams.ts
+++ b/packages/clawpilot-browser/src/teams.ts
@@ -142,7 +142,11 @@ export function normalizeTeamsTargetId(href: string): { id: string; kind: TeamsI
   }
 
   if (url.pathname.startsWith('/l/chat/')) {
-    return { id: `${url.pathname}${url.search}`, kind: 'chat' };
+    const conversationId = getTeamsConversationIdFromTarget(`${url.pathname}${url.search}`);
+    if (!conversationId) {
+      return null;
+    }
+    return { id: buildTeamsChatPath(conversationId), kind: 'chat' };
   }
 
   if (url.pathname.startsWith('/l/channel/')) {
@@ -179,9 +183,8 @@ export function buildTeamsReadResult(
   messages: TeamsMessage[],
   options: TeamsListOptions,
 ): TeamsReadResult {
-  const sorted = [...messages].sort((left, right) => left.id.localeCompare(right.id));
-  const paged = sorted.slice(options.offset, options.offset + options.limit);
-  const total = sorted.length;
+  const paged = messages.slice(options.offset, options.offset + options.limit);
+  const total = messages.length;
   const nextOffset = options.offset + options.limit < total ? options.offset + options.limit : null;
 
   return {
@@ -311,12 +314,19 @@ export async function settleTeamsAsyncAction<T>(
   timeoutMs: number,
   onTimeout: () => T,
 ): Promise<T> {
-  return Promise.race([
-    action(),
-    new Promise<T>((resolve) => {
-      setTimeout(() => resolve(onTimeout()), timeoutMs);
-    }),
-  ]);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const actionPromise = action();
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeoutId = setTimeout(() => resolve(onTimeout()), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([actionPromise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 export async function settleTeamsInteractiveLoginTrigger(
@@ -344,12 +354,25 @@ const TEAMS_TOKEN_AUDIENCES = {
 export function extractTeamsTokensFromMsalCache(
   cache: Record<string, TeamsMsalCacheEntry>,
 ): TeamsTokenSet | null {
-  const tokens: Partial<TeamsTokenSet> = {};
+  const nowEpochSeconds = Math.floor(Date.now() / 1000);
+  const tokens: Partial<
+    Record<keyof TeamsTokenSet, { secret: string; cachedAt: number; expiresAt: number }>
+  > = {};
 
   for (const entry of Object.values(cache)) {
+    const expiresAt = parseEpochSeconds(entry.expires_on) ?? 0;
+    if (expiresAt <= nowEpochSeconds) {
+      continue;
+    }
+
+    const cachedAt = parseEpochSeconds(entry.cached_at) ?? 0;
     for (const [key, audience] of Object.entries(TEAMS_TOKEN_AUDIENCES)) {
-      if (entry.target.includes(audience)) {
-        tokens[key as keyof TeamsTokenSet] = entry.secret;
+      const tokenKey = key as keyof TeamsTokenSet;
+      if (
+        entry.target.includes(audience) &&
+        shouldReplaceMsalToken(tokens[tokenKey], cachedAt, expiresAt)
+      ) {
+        tokens[tokenKey] = { secret: entry.secret, cachedAt, expiresAt };
       }
     }
   }
@@ -358,7 +381,11 @@ export function extractTeamsTokensFromMsalCache(
     return null;
   }
 
-  return tokens as TeamsTokenSet;
+  return {
+    skype: tokens.skype.secret,
+    chatSvcAgg: tokens.chatSvcAgg.secret,
+    chatSvc: tokens.chatSvc.secret,
+  };
 }
 
 function stripHtml(html: string): string {
@@ -394,10 +421,10 @@ export function parseTeamsChatListResponse(
           c.type === 'Conversation',
       )
       .map((c, i) => ({
-        id: c.id,
+        id: buildTeamsChatPath(c.id),
         kind: (c.threadProperties?.threadType === 'channel' ? 'channel' : 'chat') as TeamsItemKind,
         title: c.threadProperties?.topic ?? c.id,
-        path: `/l/chat/${encodeURIComponent(c.id)}`,
+        path: buildTeamsChatPath(c.id),
         preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
         order: i,
       }));
@@ -407,13 +434,34 @@ export function parseTeamsChatListResponse(
   return raw
     .filter((c) => !c.hidden)
     .map((c, i) => ({
-      id: c.id,
+      id: buildTeamsChatPath(c.id),
       kind: 'chat' as TeamsItemKind,
       title: c.title ?? (c.members?.map((m) => m.objectId).join(', ') || 'Unnamed chat'),
-      path: `/l/chat/${encodeURIComponent(c.id)}`,
+      path: buildTeamsChatPath(c.id),
       preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
       order: i,
     }));
+}
+
+export function mergeTeamsListCandidates(
+  preferred: TeamsListCandidate[],
+  fallback: TeamsListCandidate[],
+): TeamsListCandidate[] {
+  const merged = preferred.map((item) => ({ ...item }));
+  const seen = new Set(merged.map((item) => `${item.kind}:${item.id}`));
+  let nextOrder = merged.reduce((maxOrder, item) => Math.max(maxOrder, item.order), -1) + 1;
+
+  for (const item of fallback) {
+    const key = `${item.kind}:${item.id}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    merged.push({ ...item, order: nextOrder++ });
+    seen.add(key);
+  }
+
+  return merged;
 }
 
 const USER_MESSAGE_TYPES = new Set(['Text', 'RichText/Html', 'RichText']);
@@ -537,12 +585,7 @@ export async function listTeamsDirect(
   options: TeamsListOptions,
   fetchImpl: FetchFn = globalThis.fetch,
 ): Promise<TeamsListResult> {
-  const authz = await fetchTeamsAuthzBootstrap(tokens.skype, fetchImpl);
-  const raw = (await fetchTeamsChatList(
-    { token: tokens.chatSvcAgg, region: authz.region, partition: authz.partition },
-    fetchImpl,
-  )) as Parameters<typeof parseTeamsChatListResponse>[0];
-  const items = parseTeamsChatListResponse(raw);
+  const items = await fetchTeamsListCandidatesDirect(tokens, fetchImpl);
   return buildTeamsListResult(items, options);
 }
 
@@ -551,13 +594,19 @@ export async function readTeamsDirect(
   options: TeamsReadOptions,
   fetchImpl: FetchFn = globalThis.fetch,
 ): Promise<TeamsReadResult> {
+  const targetId = normalizeTeamsReadTargetId(options.id);
+  const conversationId = getTeamsConversationIdFromTarget(targetId);
+  if (!conversationId) {
+    throw new Error('Direct Teams read only supports chat targets.');
+  }
+
   const authz = await fetchTeamsAuthzBootstrap(tokens.skype, fetchImpl);
   const raw = (await fetchTeamsMessages(
     {
       token: tokens.chatSvc,
       region: authz.region,
       partition: authz.partition,
-      conversationId: options.id,
+      conversationId,
       pageSize: options.limit,
     },
     fetchImpl,
@@ -572,9 +621,9 @@ export async function readTeamsDirect(
     }>;
   };
   const messages = parseTeamsMessagesResponse(raw);
-  const kind: TeamsItemKind = options.id.startsWith('/l/channel/') ? 'channel' : 'chat';
+  const kind: TeamsItemKind = targetId.startsWith('/l/channel/') ? 'channel' : 'chat';
   return buildTeamsReadResult(
-    { id: options.id, kind, title: options.id, path: options.id },
+    { id: targetId, kind, title: targetId, path: targetId },
     messages,
     options,
   );
@@ -615,10 +664,11 @@ export async function listTeams(options: TeamsListOptions): Promise<TeamsListRes
     await makeWindowUnobtrusive(page);
 
     // Try direct HTTP first (faster, more reliable)
+    let directItems: TeamsListCandidate[] | null = null;
     const tokens = await extractTeamsTokensFromPage(page);
     if (tokens) {
       try {
-        return await listTeamsDirect(tokens, options);
+        directItems = await fetchTeamsListCandidatesDirect(tokens);
       } catch {
         // Fall back to DOM scraping
       }
@@ -626,10 +676,14 @@ export async function listTeams(options: TeamsListOptions): Promise<TeamsListRes
 
     const shellError = await getTeamsShellError(page);
     if (shellError) {
+      if (directItems) {
+        return buildTeamsListResult(directItems, options);
+      }
       throw new Error(shellError);
     }
 
-    const items = normalizeTeamsListNodes(await collectTeamsListNodes(page));
+    const domItems = normalizeTeamsListNodes(await collectTeamsListNodes(page));
+    const items = directItems ? mergeTeamsListCandidates(directItems, domItems) : domItems;
     if (items.length === 0) {
       throw new Error(
         'Teams loaded but no chat or channel entries were detected. Open Teams once manually, then retry.',
@@ -648,7 +702,7 @@ export async function readTeams(options: TeamsReadOptions): Promise<TeamsReadRes
 
     // Try direct HTTP first (faster, doesn't need shell loaded)
     const tokens = await extractTeamsTokensFromPage(page);
-    if (tokens) {
+    if (tokens && !normalizeTeamsReadTargetId(options.id).startsWith('/l/channel/')) {
       try {
         return await readTeamsDirect(tokens, options);
       } catch {
@@ -680,10 +734,10 @@ export async function readTeams(options: TeamsReadOptions): Promise<TeamsReadRes
 
     return buildTeamsReadResult(
       {
-        id: options.id,
-        kind: options.id.startsWith('/l/channel/') ? 'channel' : 'chat',
+        id: normalizeTeamsReadTargetId(options.id),
+        kind: normalizeTeamsReadTargetId(options.id).startsWith('/l/channel/') ? 'channel' : 'chat',
         title: await page.title(),
-        path: options.id,
+        path: normalizeTeamsReadTargetId(options.id),
       },
       messages,
       options,
@@ -1187,5 +1241,63 @@ function getTextLines(...values: Array<string | null>): string[] {
 }
 
 function resolveTeamsTargetUrl(id: string): string {
-  return new URL(id, TEAMS_BASE_URL).toString();
+  return new URL(normalizeTeamsReadTargetId(id), TEAMS_BASE_URL).toString();
+}
+
+function buildTeamsChatPath(conversationId: string): string {
+  return `/l/chat/${encodeURIComponent(conversationId)}`;
+}
+
+function normalizeTeamsReadTargetId(id: string): string {
+  if (id.startsWith('/l/')) {
+    return id;
+  }
+
+  return buildTeamsChatPath(id);
+}
+
+function getTeamsConversationIdFromTarget(id: string): string | null {
+  if (!id.startsWith('/')) {
+    return id;
+  }
+
+  const url = new URL(id, TEAMS_BASE_URL);
+  if (!isTeamsAppOrigin(url.origin) || !url.pathname.startsWith('/l/chat/')) {
+    return null;
+  }
+
+  const [, , , encodedConversationId] = url.pathname.split('/');
+  return encodedConversationId ? decodeURIComponent(encodedConversationId) : null;
+}
+
+function parseEpochSeconds(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function shouldReplaceMsalToken(
+  current: { secret: string; cachedAt: number; expiresAt: number } | undefined,
+  candidateCachedAt: number,
+  candidateExpiresAt: number,
+): boolean {
+  if (!current) {
+    return true;
+  }
+
+  return (
+    candidateCachedAt > current.cachedAt ||
+    (candidateCachedAt === current.cachedAt && candidateExpiresAt > current.expiresAt)
+  );
+}
+
+async function fetchTeamsListCandidatesDirect(
+  tokens: TeamsTokenSet,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<TeamsListCandidate[]> {
+  const authz = await fetchTeamsAuthzBootstrap(tokens.skype, fetchImpl);
+  const raw = (await fetchTeamsChatList(
+    { token: tokens.chatSvcAgg, region: authz.region, partition: authz.partition },
+    fetchImpl,
+  )) as Parameters<typeof parseTeamsChatListResponse>[0];
+  return parseTeamsChatListResponse(raw);
 }

--- a/packages/clawpilot-browser/src/teams.ts
+++ b/packages/clawpilot-browser/src/teams.ts
@@ -1,0 +1,1141 @@
+import type { BrowserContext, Page } from 'playwright';
+import {
+  createBackgroundWindowLaunchOptions,
+  makeWindowVisible,
+  makeWindowUnobtrusive,
+} from '@clawpilot/browser/utils/window.js';
+import { DEFAULT_STATE_DIR } from '@clawpilot/browser/utils/paths.js';
+
+export const TEAMS_BASE_URL = 'https://teams.cloud.microsoft';
+const FALLBACK_TEAMS_URL = 'https://teams.microsoft.com/v2/';
+const TEAMS_AUTH_CHECK_URL =
+  'https://teams.microsoft.com/api/authsvc/v1.0/authzcore?resource=https%3A%2F%2Fapi.spaces.skype.com';
+const TEAMS_CLIENT_ID = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346';
+const TEAMS_SKYPE_RESOURCE = 'https://api.spaces.skype.com';
+const TEAMS_SKYPE_SCOPE = `${TEAMS_SKYPE_RESOURCE}/.default`;
+const LOAD_TIMEOUT_MS = 30_000;
+const RENDER_WAIT_MS = 10_000;
+const TEAMS_RECOVERY_TIMEOUT_MS = 60_000;
+const TEAMS_RECOVERY_POLL_INTERVAL_MS = 5_000;
+const TEAMS_AUTH_TIMEOUT_MS = 120_000;
+const TEAMS_AUTH_POLL_INTERVAL_MS = 2_000;
+const TEAMS_AUTH_PROBE_TIMEOUT_MS = 5_000;
+const TEAMS_LOGIN_TRIGGER_TIMEOUT_MS = 5_000;
+const TEAMS_CONTEXT_CLOSE_TIMEOUT_MS = 5_000;
+
+export type TeamsAuthProbeStatus = 'authenticated' | 'interactive_auth_required' | 'probe_failed';
+export type TeamsInteractiveLoginTriggerStatus = 'triggered' | 'timed_out';
+
+export type TeamsItemKind = 'chat' | 'channel';
+
+export interface TeamsListCandidate {
+  id: string;
+  kind: TeamsItemKind;
+  title: string;
+  path: string;
+  preview: string | null;
+  order: number;
+}
+
+export interface TeamsPageInfo {
+  limit: number;
+  offset: number;
+  total: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}
+
+export interface TeamsListResult {
+  page: TeamsPageInfo;
+  chats: TeamsListCandidate[];
+  channels: TeamsListCandidate[];
+}
+
+export interface TeamsMessage {
+  id: string;
+  author: string | null;
+  sentAt: string | null;
+  text: string;
+}
+
+export interface TeamsReadTarget {
+  id: string;
+  kind: TeamsItemKind;
+  title: string;
+  path: string;
+}
+
+export interface TeamsReadResult {
+  target: TeamsReadTarget;
+  page: TeamsPageInfo;
+  messages: TeamsMessage[];
+}
+
+export interface TeamsListOptions {
+  limit: number;
+  offset: number;
+}
+
+export interface TeamsReadOptions extends TeamsListOptions {
+  id: string;
+}
+
+interface RawTeamsListNode {
+  href: string | null;
+  text: string;
+  aria: string | null;
+  title: string | null;
+  dataTid: string | null;
+  role: string | null;
+  dataChatId: string | null;
+  dataChannelId: string | null;
+  dataTeamId: string | null;
+  dataPreview: string | null;
+  order: number;
+}
+
+interface RawTeamsMessageNode {
+  messageId: string | null;
+  text: string;
+  aria: string | null;
+  title: string | null;
+  dataTid: string | null;
+  order: number;
+}
+
+interface TeamsShellSnapshot {
+  bodyText: string;
+  buttonTexts: string[];
+}
+
+interface TeamsAuthProbeResult {
+  status: number | null;
+  pageOrigin: string;
+}
+
+// --- Direct HTTP client types ---
+
+export interface TeamsMsalCacheEntry {
+  secret: string;
+  target: string;
+  expires_on: string;
+  cached_at: string;
+}
+
+export interface TeamsTokenSet {
+  skype: string;
+  chatSvcAgg: string;
+  chatSvc: string;
+}
+
+export function normalizeTeamsTargetId(href: string): { id: string; kind: TeamsItemKind } | null {
+  const url = new URL(href, TEAMS_BASE_URL);
+  const isTeamsOrigin = [TEAMS_BASE_URL, 'https://teams.microsoft.com'].includes(url.origin);
+
+  if (!isTeamsOrigin) {
+    return null;
+  }
+
+  if (url.pathname.startsWith('/l/chat/')) {
+    return { id: `${url.pathname}${url.search}`, kind: 'chat' };
+  }
+
+  if (url.pathname.startsWith('/l/channel/')) {
+    return { id: `${url.pathname}${url.search}`, kind: 'channel' };
+  }
+
+  return null;
+}
+
+export function buildTeamsListResult(
+  items: TeamsListCandidate[],
+  options: TeamsListOptions,
+): TeamsListResult {
+  const sorted = [...items].sort((left, right) => left.order - right.order);
+  const paged = sorted.slice(options.offset, options.offset + options.limit);
+  const total = sorted.length;
+  const nextOffset = options.offset + options.limit < total ? options.offset + options.limit : null;
+
+  return {
+    page: {
+      limit: options.limit,
+      offset: options.offset,
+      total,
+      hasMore: nextOffset !== null,
+      nextOffset,
+    },
+    chats: paged.filter((item) => item.kind === 'chat'),
+    channels: paged.filter((item) => item.kind === 'channel'),
+  };
+}
+
+export function buildTeamsReadResult(
+  target: TeamsReadTarget,
+  messages: TeamsMessage[],
+  options: TeamsListOptions,
+): TeamsReadResult {
+  const sorted = [...messages].sort((left, right) => left.id.localeCompare(right.id));
+  const paged = sorted.slice(options.offset, options.offset + options.limit);
+  const total = sorted.length;
+  const nextOffset = options.offset + options.limit < total ? options.offset + options.limit : null;
+
+  return {
+    target,
+    page: {
+      limit: options.limit,
+      offset: options.offset,
+      total,
+      hasMore: nextOffset !== null,
+      nextOffset,
+    },
+    messages: paged,
+  };
+}
+
+export function formatTeamsList(result: TeamsListResult): string {
+  const lines = [
+    `Teams conversations (${result.page.total} total, showing ${
+      result.chats.length + result.channels.length
+    }, offset ${result.page.offset}, limit ${result.page.limit})`,
+    '',
+    'Chats',
+  ];
+
+  if (result.chats.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const chat of result.chats) {
+      lines.push(`- ${chat.title}`);
+      lines.push(`  ID: ${chat.id}`);
+      lines.push(`  Path: ${chat.path}`);
+      if (chat.preview) {
+        lines.push(`  Preview: ${chat.preview}`);
+      }
+    }
+  }
+
+  lines.push('', 'Channels');
+
+  if (result.channels.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const channel of result.channels) {
+      lines.push(`- ${channel.title}`);
+      lines.push(`  ID: ${channel.id}`);
+      lines.push(`  Path: ${channel.path}`);
+      if (channel.preview) {
+        lines.push(`  Preview: ${channel.preview}`);
+      }
+    }
+  }
+
+  if (result.page.hasMore && result.page.nextOffset !== null) {
+    lines.push('', `Next offset: ${result.page.nextOffset}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function formatTeamsRead(result: TeamsReadResult): string {
+  const lines = [
+    `${result.target.title} (${result.target.kind})`,
+    `ID: ${result.target.id}`,
+    `Path: ${result.target.path}`,
+    '',
+    `Messages (${result.messages.length})`,
+  ];
+
+  if (result.messages.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const message of result.messages) {
+      const header = [message.author, message.sentAt].filter(Boolean).join(' — ');
+      lines.push(`- ${header || message.id}`);
+      lines.push(`  ${message.text}`);
+    }
+  }
+
+  if (result.page.hasMore && result.page.nextOffset !== null) {
+    lines.push('', `Next offset: ${result.page.nextOffset}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function detectTeamsShellError(snapshot: TeamsShellSnapshot): string | null {
+  const normalizedButtons = snapshot.buttonTexts.map((button) => button.trim().toLowerCase());
+
+  if (!normalizedButtons.includes('retry')) {
+    return null;
+  }
+
+  const detail = getTeamsShellErrorDetail(snapshot);
+  return `Teams web client reached its retry screen ("${detail}"). Open Teams manually and let it finish loading, then retry.`;
+}
+
+export function formatTeamsShellErrorMessage(detail: string, waitedSeconds: number): string {
+  return `Teams web client stayed on its retry screen for ${waitedSeconds} seconds ("${detail}"). Open Teams manually and let it finish loading, then retry.`;
+}
+
+export function classifyTeamsAuthProbeStatus(status: number): TeamsAuthProbeStatus {
+  if (status >= 200 && status < 300) {
+    return 'authenticated';
+  }
+
+  if (status === 401) {
+    return 'interactive_auth_required';
+  }
+
+  return 'probe_failed';
+}
+
+export function formatTeamsAuthTimeoutMessage(waitedSeconds: number): string {
+  return `Teams needs an interactive sign-in before chats or channels can be read. A Teams window was opened and waited for ${waitedSeconds} seconds, but auth never became ready. Finish signing in there, then retry.`;
+}
+
+export async function settleTeamsAsyncAction<T>(
+  action: () => Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => T,
+): Promise<T> {
+  return Promise.race([
+    action(),
+    new Promise<T>((resolve) => {
+      setTimeout(() => resolve(onTimeout()), timeoutMs);
+    }),
+  ]);
+}
+
+export async function settleTeamsInteractiveLoginTrigger(
+  triggerLogin: () => Promise<void>,
+  timeoutMs: number,
+): Promise<TeamsInteractiveLoginTriggerStatus> {
+  return settleTeamsAsyncAction(
+    async () => {
+      await triggerLogin();
+      return 'triggered' as const;
+    },
+    timeoutMs,
+    () => 'timed_out',
+  );
+}
+
+// --- Direct HTTP client: pure token extraction & response parsing ---
+
+const TEAMS_TOKEN_AUDIENCES = {
+  skype: 'https://api.spaces.skype.com',
+  chatSvcAgg: 'https://chatsvcagg.teams.microsoft.com',
+  chatSvc: 'https://ic3.teams.office.com',
+} as const;
+
+export function extractTeamsTokensFromMsalCache(
+  cache: Record<string, TeamsMsalCacheEntry>,
+): TeamsTokenSet | null {
+  const tokens: Partial<TeamsTokenSet> = {};
+
+  for (const entry of Object.values(cache)) {
+    for (const [key, audience] of Object.entries(TEAMS_TOKEN_AUDIENCES)) {
+      if (entry.target.includes(audience)) {
+        tokens[key as keyof TeamsTokenSet] = entry.secret;
+      }
+    }
+  }
+
+  if (!tokens.skype || !tokens.chatSvcAgg || !tokens.chatSvc) {
+    return null;
+  }
+
+  return tokens as TeamsTokenSet;
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '').trim();
+}
+
+export function parseTeamsChatListResponse(
+  raw: Array<{
+    id: string;
+    title: string | null;
+    chatType: string;
+    lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
+    members?: Array<{ objectId: string }>;
+    hidden?: boolean;
+  }>,
+): TeamsListCandidate[] {
+  return raw
+    .filter((c) => !c.hidden)
+    .map((c, i) => ({
+      id: c.id,
+      kind: 'chat' as TeamsItemKind,
+      title: c.title ?? (c.members?.map((m) => m.objectId).join(', ') || 'Unnamed chat'),
+      path: `/l/chat/${encodeURIComponent(c.id)}`,
+      preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
+      order: i,
+    }));
+}
+
+const USER_MESSAGE_TYPES = new Set(['Text', 'RichText/Html', 'RichText']);
+
+export function parseTeamsMessagesResponse(raw: {
+  messages: Array<{
+    id: string;
+    imdisplayname: string;
+    composetime: string;
+    content: string;
+    messagetype: string;
+    type: string;
+  }>;
+}): TeamsMessage[] {
+  return raw.messages
+    .filter((m) => USER_MESSAGE_TYPES.has(m.messagetype))
+    .map((m) => ({
+      id: m.id,
+      author: m.imdisplayname || null,
+      sentAt: m.composetime || null,
+      text: stripHtml(m.content),
+    }));
+}
+
+// --- Direct HTTP client: fetch functions ---
+
+type FetchFn = typeof globalThis.fetch;
+
+export interface TeamsAuthzBootstrapResult {
+  region: string;
+  partition: string;
+  skypeToken: string;
+}
+
+const TEAMS_DATA_HEADERS = {
+  'x-ms-client-type': 'web',
+  'x-ms-client-version': '1415/26021215123',
+  'x-ms-migration': 'True',
+} as const;
+
+export async function fetchTeamsAuthzBootstrap(
+  skypeAudienceToken: string,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<TeamsAuthzBootstrapResult> {
+  const response = await fetchImpl('https://teams.microsoft.com/api/authsvc/v1.0/authz', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${skypeAudienceToken}`,
+      ...TEAMS_DATA_HEADERS,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Teams authz bootstrap failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    region: string;
+    partition: string;
+    tokens: { skypeToken: string };
+  };
+
+  return {
+    region: data.region,
+    partition: data.partition,
+    skypeToken: data.tokens.skypeToken,
+  };
+}
+
+export async function fetchTeamsChatList(
+  opts: { token: string; region: string; partition: string },
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<unknown> {
+  const url = `https://teams.cloud.microsoft/api/csa/${opts.region}/api/v1/teams/users/me/groupchats?skipMeetingChats=true`;
+  const response = await fetchImpl(url, {
+    headers: {
+      authorization: `Bearer ${opts.token}`,
+      'x-ms-region': opts.region,
+      'x-ms-partition': opts.partition,
+      ...TEAMS_DATA_HEADERS,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Teams chat list failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchTeamsMessages(
+  opts: {
+    token: string;
+    region: string;
+    partition: string;
+    conversationId: string;
+    pageSize: number;
+  },
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<unknown> {
+  const encodedId = encodeURIComponent(opts.conversationId);
+  const url = `https://teams.cloud.microsoft/api/chatsvc/${opts.region}/v1/users/ME/conversations/${encodedId}/messages?view=msnp24Equivalent|supportsMessageProperties&pageSize=${opts.pageSize}&startTime=1`;
+  const response = await fetchImpl(url, {
+    headers: {
+      authorization: `Bearer ${opts.token}`,
+      'x-ms-region': opts.region,
+      'x-ms-partition': opts.partition,
+      ...TEAMS_DATA_HEADERS,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Teams messages failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function listTeamsDirect(
+  tokens: TeamsTokenSet,
+  options: TeamsListOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<TeamsListResult> {
+  const authz = await fetchTeamsAuthzBootstrap(tokens.skype, fetchImpl);
+  const raw = (await fetchTeamsChatList(
+    { token: tokens.chatSvcAgg, region: authz.region, partition: authz.partition },
+    fetchImpl,
+  )) as Array<{
+    id: string;
+    title: string | null;
+    chatType: string;
+    lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
+    members?: Array<{ objectId: string }>;
+    hidden?: boolean;
+  }>;
+  const items = parseTeamsChatListResponse(raw);
+  return buildTeamsListResult(items, options);
+}
+
+export async function readTeamsDirect(
+  tokens: TeamsTokenSet,
+  options: TeamsReadOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<TeamsReadResult> {
+  const authz = await fetchTeamsAuthzBootstrap(tokens.skype, fetchImpl);
+  const raw = (await fetchTeamsMessages(
+    {
+      token: tokens.chatSvc,
+      region: authz.region,
+      partition: authz.partition,
+      conversationId: options.id,
+      pageSize: options.limit,
+    },
+    fetchImpl,
+  )) as {
+    messages: Array<{
+      id: string;
+      imdisplayname: string;
+      composetime: string;
+      content: string;
+      messagetype: string;
+      type: string;
+    }>;
+  };
+  const messages = parseTeamsMessagesResponse(raw);
+  const kind: TeamsItemKind = options.id.startsWith('/l/channel/') ? 'channel' : 'chat';
+  return buildTeamsReadResult(
+    { id: options.id, kind, title: options.id, path: options.id },
+    messages,
+    options,
+  );
+}
+
+async function extractTeamsTokensFromPage(page: Page): Promise<TeamsTokenSet | null> {
+  const msalEntries = await page.evaluate(() => {
+    const entries: Record<
+      string,
+      { secret: string; target: string; expires_on: string; cached_at: string }
+    > = {};
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key?.includes('-accesstoken-')) continue;
+      try {
+        const val = JSON.parse(localStorage.getItem(key) ?? '');
+        if (val && typeof val.secret === 'string' && typeof val.target === 'string') {
+          entries[key] = val as {
+            secret: string;
+            target: string;
+            expires_on: string;
+            cached_at: string;
+          };
+        }
+      } catch {
+        // skip non-JSON entries
+      }
+    }
+    return entries;
+  });
+  return extractTeamsTokensFromMsalCache(msalEntries);
+}
+
+export async function listTeams(options: TeamsListOptions): Promise<TeamsListResult> {
+  return withTeamsPage(async (page) => {
+    await loadTeamsShell(page);
+    await ensureTeamsAuthReady(page);
+    await makeWindowUnobtrusive(page);
+    const shellError = await getTeamsShellError(page);
+    if (shellError) {
+      throw new Error(shellError);
+    }
+
+    // Try direct HTTP first (faster, more reliable)
+    const tokens = await extractTeamsTokensFromPage(page);
+    if (tokens) {
+      try {
+        return await listTeamsDirect(tokens, options);
+      } catch {
+        // Fall back to DOM scraping
+      }
+    }
+
+    const items = normalizeTeamsListNodes(await collectTeamsListNodes(page));
+    if (items.length === 0) {
+      throw new Error(
+        'Teams loaded but no chat or channel entries were detected. Open Teams once manually, then retry.',
+      );
+    }
+
+    return buildTeamsListResult(items, options);
+  });
+}
+
+export async function readTeams(options: TeamsReadOptions): Promise<TeamsReadResult> {
+  return withTeamsPage(async (page) => {
+    await loadTeamsShell(page);
+    await ensureTeamsAuthReady(page);
+    await makeWindowUnobtrusive(page);
+    const shellError = await getTeamsShellError(page);
+    if (shellError) {
+      throw new Error(shellError);
+    }
+
+    // Try direct HTTP first (faster, more reliable)
+    const tokens = await extractTeamsTokensFromPage(page);
+    if (tokens) {
+      try {
+        return await readTeamsDirect(tokens, options);
+      } catch {
+        // Fall back to DOM scraping
+      }
+    }
+
+    await page.goto(resolveTeamsTargetUrl(options.id), {
+      timeout: LOAD_TIMEOUT_MS,
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForTimeout(RENDER_WAIT_MS);
+    const targetShellError = await getTeamsShellError(page);
+    if (targetShellError) {
+      throw new Error(targetShellError);
+    }
+
+    const messages = normalizeTeamsMessages(await collectTeamsMessageNodes(page));
+    if (messages.length === 0) {
+      throw new Error(
+        'Teams opened the target but no messages were detected. Open the thread/channel manually, then retry.',
+      );
+    }
+
+    return buildTeamsReadResult(
+      {
+        id: options.id,
+        kind: options.id.startsWith('/l/channel/') ? 'channel' : 'chat',
+        title: await page.title(),
+        path: options.id,
+      },
+      messages,
+      options,
+    );
+  });
+}
+
+async function withTeamsPage<T>(run: (page: Page) => Promise<T>): Promise<T> {
+  const { chromium } = await import('playwright');
+  let context: BrowserContext | undefined;
+
+  try {
+    context = await chromium.launchPersistentContext(DEFAULT_STATE_DIR, {
+      ...createBackgroundWindowLaunchOptions(),
+    });
+    const page = context.pages()[0] ?? (await context.newPage());
+    await makeWindowUnobtrusive(page);
+    return await run(page);
+  } finally {
+    if (context) {
+      const contextToClose = context;
+      await settleTeamsAsyncAction(
+        () => contextToClose.close(),
+        TEAMS_CONTEXT_CLOSE_TIMEOUT_MS,
+        () => undefined,
+      );
+    }
+  }
+}
+
+async function loadTeamsShell(page: Page): Promise<void> {
+  await page.goto(TEAMS_BASE_URL, {
+    timeout: LOAD_TIMEOUT_MS,
+    waitUntil: 'domcontentloaded',
+  });
+  await page.waitForTimeout(RENDER_WAIT_MS);
+
+  if (await isRetryShell(page)) {
+    await page.goto(FALLBACK_TEAMS_URL, {
+      timeout: LOAD_TIMEOUT_MS,
+      waitUntil: 'domcontentloaded',
+    });
+    await waitForTeamsRecovery(page);
+  }
+}
+
+async function maybeRetryShell(page: Page): Promise<void> {
+  const retryButton = page.getByRole('button', { name: 'Retry' });
+  if (await retryButton.count()) {
+    await retryButton.first().click();
+  }
+}
+
+async function isRetryShell(page: Page): Promise<boolean> {
+  const buttons = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('button')).map((button) =>
+      (button.textContent ?? '').trim().toLowerCase(),
+    ),
+  );
+
+  return buttons.includes('retry');
+}
+
+async function getTeamsShellError(page: Page): Promise<string | null> {
+  const snapshot = await page.evaluate(() => ({
+    bodyText: document.body.innerText ?? '',
+    buttonTexts: Array.from(document.querySelectorAll('button')).map((button) =>
+      (button.textContent ?? '').trim(),
+    ),
+  }));
+
+  return detectTeamsShellError(snapshot);
+}
+
+function getTeamsShellErrorDetail(snapshot: TeamsShellSnapshot): string {
+  const lines = snapshot.bodyText
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return (
+    lines.find(
+      (line) =>
+        !/^oops$/i.test(line) && !/^retry$/i.test(line) && !/^clear cache and retry$/i.test(line),
+    ) ?? 'Teams hit an unknown client-side error'
+  );
+}
+
+async function waitForTeamsRecovery(page: Page): Promise<void> {
+  const deadline = Date.now() + TEAMS_RECOVERY_TIMEOUT_MS;
+
+  while (true) {
+    await maybeRetryShell(page);
+    await page.waitForTimeout(RENDER_WAIT_MS);
+
+    const snapshot = await page.evaluate(() => ({
+      bodyText: document.body.innerText ?? '',
+      buttonTexts: Array.from(document.querySelectorAll('button')).map((button) =>
+        (button.textContent ?? '').trim(),
+      ),
+    }));
+
+    const shellError = detectTeamsShellError(snapshot);
+    if (!shellError) {
+      return;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        formatTeamsShellErrorMessage(
+          getTeamsShellErrorDetail(snapshot),
+          Math.round(TEAMS_RECOVERY_TIMEOUT_MS / 1000),
+        ),
+      );
+    }
+
+    const waitTime = Math.min(TEAMS_RECOVERY_POLL_INTERVAL_MS, deadline - Date.now());
+    if (waitTime > 0) {
+      await page.waitForTimeout(waitTime);
+    }
+  }
+}
+
+async function ensureTeamsAuthReady(page: Page): Promise<void> {
+  if (new URL(page.url()).origin !== 'https://teams.microsoft.com') {
+    await page.goto(FALLBACK_TEAMS_URL, {
+      timeout: LOAD_TIMEOUT_MS,
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForTimeout(RENDER_WAIT_MS);
+  }
+
+  const deadline = Date.now() + TEAMS_AUTH_TIMEOUT_MS;
+  let madeVisible = false;
+  let loginTriggered = false;
+
+  while (true) {
+    const probe = await probeTeamsAuth(page);
+    const status =
+      probe.status === null
+        ? 'interactive_auth_required'
+        : classifyTeamsAuthProbeStatus(probe.status);
+
+    if (status === 'authenticated') {
+      return;
+    }
+
+    if (status === 'probe_failed') {
+      throw new Error(
+        `Teams auth probe failed with status ${probe.status}. Open Teams manually, finish signing in, then retry.`,
+      );
+    }
+
+    if (!madeVisible) {
+      await makeWindowVisible(page);
+      madeVisible = true;
+    }
+
+    if (!loginTriggered && probe.pageOrigin === 'https://teams.microsoft.com') {
+      await triggerTeamsInteractiveLogin(page);
+      loginTriggered = true;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(formatTeamsAuthTimeoutMessage(Math.round(TEAMS_AUTH_TIMEOUT_MS / 1000)));
+    }
+
+    if (probe.pageOrigin === 'https://teams.microsoft.com') {
+      await page.waitForTimeout(TEAMS_AUTH_POLL_INTERVAL_MS);
+      continue;
+    }
+
+    await page.waitForTimeout(TEAMS_AUTH_POLL_INTERVAL_MS);
+  }
+}
+
+async function probeTeamsAuth(page: Page): Promise<TeamsAuthProbeResult> {
+  return settleTeamsAsyncAction(
+    () =>
+      page.evaluate(
+        async ({ authUrl, probeTimeoutMs }) => {
+          if (window.location.origin !== 'https://teams.microsoft.com') {
+            return {
+              status: null,
+              pageOrigin: window.location.origin,
+            };
+          }
+
+          try {
+            const controller = new AbortController();
+            const timeoutId = window.setTimeout(() => controller.abort(), probeTimeoutMs);
+            const response = await fetch(authUrl, {
+              credentials: 'include',
+              method: 'GET',
+              signal: controller.signal,
+            });
+            window.clearTimeout(timeoutId);
+
+            return {
+              status: response.status,
+              pageOrigin: window.location.origin,
+            };
+          } catch {
+            return {
+              status: 0,
+              pageOrigin: window.location.origin,
+            };
+          }
+        },
+        { authUrl: TEAMS_AUTH_CHECK_URL, probeTimeoutMs: TEAMS_AUTH_PROBE_TIMEOUT_MS },
+      ),
+    TEAMS_AUTH_PROBE_TIMEOUT_MS + 1_000,
+    () => ({
+      status: null,
+      pageOrigin: new URL(page.url()).origin,
+    }),
+  );
+}
+
+async function triggerTeamsInteractiveLogin(page: Page): Promise<void> {
+  await settleTeamsInteractiveLoginTrigger(
+    () =>
+      page.evaluate(
+        async ({ clientId, skypeResource, skypeScope }) => {
+          const runtime = self as typeof self & {
+            webpackChunk_msteams_react_web_client?: Array<unknown> & {
+              push: (payload: unknown) => void;
+            };
+          };
+          const chunk = runtime.webpackChunk_msteams_react_web_client;
+          if (!chunk) {
+            return;
+          }
+          let runtimeRequire: ((id: number) => unknown) | undefined;
+          chunk.push([
+            [Symbol('clawpilot')],
+            {},
+            (require: (id: number) => unknown): void => {
+              runtimeRequire = require;
+            },
+          ]);
+
+          if (!runtimeRequire) {
+            return;
+          }
+
+          const providerModule = runtimeRequire(844084) as {
+            Msal2AuthenticationProvider: new (
+              config: unknown,
+              currentUrl: unknown,
+              windowProvider: unknown,
+              crossTabCallbacks: unknown,
+              coreSettings: (key: string) => unknown,
+            ) => {
+              _userAgentApplication: {
+                initialize: () => Promise<void>;
+                loginRedirect: (request: unknown) => Promise<void>;
+              };
+            };
+          };
+
+          const Provider = providerModule.Msal2AuthenticationProvider;
+          const currentUrl = {
+            origin: window.location.origin,
+            pathname: window.location.pathname,
+            queryStrings: Object.fromEntries(new URLSearchParams(window.location.search).entries()),
+          };
+          const settings: Record<string, unknown> = {
+            clientId,
+            instanceUrl: 'https://login.microsoftonline.com/',
+            redirectUrlPath: 'v2/',
+            audience: 'common',
+            authMsalIframeHashTimeout: '40000',
+            enableBlankPageRedirectUri: true,
+            mtResource: skypeResource,
+            mtResourceV2: skypeResource,
+            buildCloud: 'prod',
+            enableAadV2TokenForMiddleTier: false,
+            interactionRequiredErrorCodes: [
+              'login_required',
+              'consent_required',
+              'interaction_required',
+              'InteractionRequired',
+              'UserCanceled',
+              'UserCancelled',
+              'NoAccountFound',
+              'AccountUnusable',
+              'invalid_grant',
+              'no_tokens_found',
+              'native_account_unavailable',
+              'refresh_token_expired',
+              'bad_token',
+            ],
+            acquireTokenRetryableErrorCodeList: [
+              'NoNetwork',
+              'NetworkTemporarilyUnavailable',
+              'NoAccountFound',
+            ],
+            pathForAcquireTokenRedirect: 'v2/',
+            retainedQspsForAcquireTokenRedirect: ['loginHint', 'tenantId'],
+          };
+
+          const provider = new Provider(
+            {
+              clientId,
+              cacheLocation: 'localStorage',
+              isInIframe: false,
+              webAuth: { navigateToLoginRequestUrl: false },
+              experienceName: 'react-web-client',
+              clientVersion: '26021215123',
+            },
+            currentUrl,
+            { localStorage: window.localStorage },
+            {},
+            (key: string) => settings[key],
+          );
+
+          await provider._userAgentApplication.initialize();
+          provider._userAgentApplication
+            .loginRedirect({
+              scopes: ['openid', 'profile', 'offline_access', skypeScope],
+              redirectStartPage: `${window.location.origin}/v2/`,
+              redirectUri: `${window.location.origin}/v2/`,
+            })
+            .catch(() => undefined);
+        },
+        {
+          clientId: TEAMS_CLIENT_ID,
+          skypeResource: TEAMS_SKYPE_RESOURCE,
+          skypeScope: TEAMS_SKYPE_SCOPE,
+        },
+      ),
+    TEAMS_LOGIN_TRIGGER_TIMEOUT_MS,
+  );
+}
+
+async function collectTeamsListNodes(page: Page): Promise<RawTeamsListNode[]> {
+  return page.evaluate(() => {
+    const selector = [
+      'a[href*="/l/chat/"]',
+      'a[href*="/l/channel/"]',
+      '[data-chat-id]',
+      '[data-channel-id]',
+      '[role="treeitem"]',
+      '[role="listitem"]',
+      'button',
+    ].join(', ');
+
+    const nodes = Array.from(document.querySelectorAll(selector));
+    return nodes.slice(0, 600).map((node, index) => {
+      const element = node as HTMLElement;
+      const dataset = element.dataset ?? {};
+      const href = element instanceof HTMLAnchorElement ? element.href : null;
+      const lines = (element.innerText || element.textContent || '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      return {
+        href,
+        text: lines.join('\n'),
+        aria: element.getAttribute('aria-label'),
+        title: element.getAttribute('title'),
+        dataTid: element.getAttribute('data-tid'),
+        role: element.getAttribute('role'),
+        dataChatId: dataset.chatId ?? null,
+        dataChannelId: dataset.channelId ?? null,
+        dataTeamId: dataset.teamId ?? null,
+        dataPreview: dataset.preview ?? null,
+        order: index,
+      };
+    });
+  });
+}
+
+async function collectTeamsMessageNodes(page: Page): Promise<RawTeamsMessageNode[]> {
+  return page.evaluate(() => {
+    const selector = [
+      '[data-message-id]',
+      '[data-tid*="message"]',
+      'article',
+      '[role="listitem"]',
+    ].join(', ');
+
+    return Array.from(document.querySelectorAll(selector))
+      .slice(0, 1000)
+      .map((node, index) => {
+        const element = node as HTMLElement;
+        return {
+          messageId: element.dataset.messageId ?? null,
+          text: (element.innerText || element.textContent || '').trim(),
+          aria: element.getAttribute('aria-label'),
+          title: element.getAttribute('title'),
+          dataTid: element.getAttribute('data-tid'),
+          order: index,
+        };
+      });
+  });
+}
+
+function normalizeTeamsListNodes(nodes: RawTeamsListNode[]): TeamsListCandidate[] {
+  const seen = new Set<string>();
+  const items: TeamsListCandidate[] = [];
+
+  for (const node of nodes) {
+    const identity =
+      (node.href ? normalizeTeamsTargetId(node.href) : null) ?? deriveTargetFromDataset(node);
+    if (!identity || seen.has(identity.id)) {
+      continue;
+    }
+
+    const lines = getTextLines(node.text, node.aria, node.title);
+    const title = lines[0] ?? identity.id;
+    const preview = node.dataPreview ?? lines[1] ?? null;
+    const path = identity.kind === 'channel' && lines.length > 1 ? `${title} / ${lines[1]}` : title;
+
+    items.push({
+      id: identity.id,
+      kind: identity.kind,
+      title,
+      path,
+      preview,
+      order: node.order,
+    });
+    seen.add(identity.id);
+  }
+
+  return items;
+}
+
+function deriveTargetFromDataset(
+  node: RawTeamsListNode,
+): { id: string; kind: TeamsItemKind } | null {
+  if (node.dataChatId) {
+    return { id: `/l/chat/${encodeURIComponent(node.dataChatId)}`, kind: 'chat' };
+  }
+
+  if (node.dataChannelId) {
+    const groupQuery = node.dataTeamId ? `?groupId=${encodeURIComponent(node.dataTeamId)}` : '';
+    return {
+      id: `/l/channel/${encodeURIComponent(node.dataChannelId)}/${encodeURIComponent(node.title ?? 'channel')}${groupQuery}`,
+      kind: 'channel',
+    };
+  }
+
+  return null;
+}
+
+function normalizeTeamsMessages(nodes: RawTeamsMessageNode[]): TeamsMessage[] {
+  const messages: TeamsMessage[] = [];
+  const seen = new Set<string>();
+
+  for (const node of nodes) {
+    const lines = getTextLines(node.text, node.aria, node.title);
+    if (lines.length === 0) {
+      continue;
+    }
+
+    const id = node.messageId ?? `message-${node.order}`;
+    if (seen.has(id)) {
+      continue;
+    }
+
+    const [author, sentAt, ...rest] = lines;
+    const text = rest.length > 0 ? rest.join(' ') : lines.join(' ');
+
+    if (!text) {
+      continue;
+    }
+
+    messages.push({
+      id,
+      author: rest.length > 0 ? (author ?? null) : null,
+      sentAt: rest.length > 0 ? (sentAt ?? null) : null,
+      text,
+    });
+    seen.add(id);
+  }
+
+  return messages;
+}
+
+function getTextLines(...values: Array<string | null>): string[] {
+  return values
+    .flatMap((value) => (value ?? '').split('\n'))
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function resolveTeamsTargetUrl(id: string): string {
+  return new URL(id, TEAMS_BASE_URL).toString();
+}

--- a/packages/clawpilot-browser/src/utils/__tests__/window.test.ts
+++ b/packages/clawpilot-browser/src/utils/__tests__/window.test.ts
@@ -9,6 +9,7 @@ describe('createBackgroundWindowLaunchOptions', () => {
   it('creates a headed tiny offscreen browser configuration', () => {
     const options = createBackgroundWindowLaunchOptions();
 
+    expect(options.channel).toBe('chrome');
     expect(options.headless).toBe(false);
     expect(options.viewport).toBeNull();
     expect(options.args).toEqual(

--- a/packages/clawpilot-browser/src/utils/window.ts
+++ b/packages/clawpilot-browser/src/utils/window.ts
@@ -4,6 +4,10 @@ const BACKGROUND_WINDOW_WIDTH = 480;
 const BACKGROUND_WINDOW_HEIGHT = 320;
 const BACKGROUND_WINDOW_X = 3000;
 const BACKGROUND_WINDOW_Y = 3000;
+const FOREGROUND_WINDOW_WIDTH = 1280;
+const FOREGROUND_WINDOW_HEIGHT = 900;
+const FOREGROUND_WINDOW_X = 100;
+const FOREGROUND_WINDOW_Y = 100;
 
 export function createBackgroundWindowLaunchOptions(): {
   headless: false;
@@ -35,5 +39,29 @@ export async function makeWindowUnobtrusive(page: Page): Promise<void> {
     });
   } catch {
     // The offscreen/tiny launch args are already applied. Minimize is best-effort.
+  }
+}
+
+export async function makeWindowVisible(page: Page): Promise<void> {
+  try {
+    const session = await page.context().newCDPSession(page);
+    const window = (await session.send('Browser.getWindowForTarget')) as { windowId?: number };
+
+    if (typeof window.windowId !== 'number') {
+      return;
+    }
+
+    await session.send('Browser.setWindowBounds', {
+      windowId: window.windowId,
+      bounds: {
+        windowState: 'normal',
+        left: FOREGROUND_WINDOW_X,
+        top: FOREGROUND_WINDOW_Y,
+        width: FOREGROUND_WINDOW_WIDTH,
+        height: FOREGROUND_WINDOW_HEIGHT,
+      },
+    });
+  } catch {
+    // Best-effort only. The window is still available even if resizing/restoring fails.
   }
 }

--- a/packages/clawpilot-browser/src/utils/window.ts
+++ b/packages/clawpilot-browser/src/utils/window.ts
@@ -10,11 +10,13 @@ const FOREGROUND_WINDOW_X = 100;
 const FOREGROUND_WINDOW_Y = 100;
 
 export function createBackgroundWindowLaunchOptions(): {
+  channel: 'chrome';
   headless: false;
   viewport: null;
   args: string[];
 } {
   return {
+    channel: 'chrome',
     headless: false,
     viewport: null,
     args: [

--- a/scripts/check-typescript-guidelines.mjs
+++ b/scripts/check-typescript-guidelines.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx']);
+const LARGE_FILE_WARNING_LINES = 300;
+const MANY_EXPORTS_WARNING_COUNT = 8;
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+const repoRoot = git(['rev-parse', '--show-toplevel']);
+
+function gitInRepo(args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function parseArgs(argv) {
+  const files = [];
+  let useStaged = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--staged') {
+      useStaged = true;
+      continue;
+    }
+    if (arg === '--files') {
+      for (let fileIndex = index + 1; fileIndex < argv.length; fileIndex += 1) {
+        files.push(argv[fileIndex]);
+      }
+      break;
+    }
+  }
+
+  return { useStaged, files };
+}
+
+function getStagedTypeScriptFiles() {
+  const output = gitInRepo(['diff', '--cached', '--name-only', '--diff-filter=ACMR', '--', '*.ts', '*.tsx']);
+  return output
+    .split('\n')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function normalizeFileInput(file) {
+  const absolutePath = path.isAbsolute(file) ? file : path.join(repoRoot, file);
+  const extension = path.extname(absolutePath);
+  if (!SUPPORTED_EXTENSIONS.has(extension)) {
+    return null;
+  }
+  const relativePath = path.isAbsolute(file) ? path.relative(repoRoot, absolutePath) : file;
+  return { absolutePath, relativePath };
+}
+
+function readFileContent(file, useStaged) {
+  if (useStaged) {
+    return gitInRepo(['show', `:${file.relativePath}`]);
+  }
+  if (!existsSync(file.absolutePath)) {
+    throw new Error(`File does not exist: ${file.absolutePath}`);
+  }
+  return readFileSync(file.absolutePath, 'utf8');
+}
+
+function getLineNumber(content, index) {
+  return content.slice(0, index).split('\n').length;
+}
+
+function collectMatches(content, pattern) {
+  const matches = [];
+  let match;
+  pattern.lastIndex = 0;
+  while ((match = pattern.exec(content)) !== null) {
+    matches.push({
+      index: match.index,
+      line: getLineNumber(content, match.index),
+      text: match[0],
+    });
+  }
+  return matches;
+}
+
+function inspectFile(file, content) {
+  const failures = [];
+  const warnings = [];
+  const lineCount = content.split('\n').length;
+  const isPackageSource = /^packages\/[^/]+\/src\/.+\.(ts|tsx)$/.test(file.relativePath);
+  const isTestFile =
+    /(?:^|\/)__tests__\//.test(file.relativePath) ||
+    /\.test\.(ts|tsx)$/.test(file.relativePath) ||
+    /\.spec\.(ts|tsx)$/.test(file.relativePath);
+
+  const failPatterns = [
+    {
+      rule: 'ts-suppression',
+      pattern: /@ts-ignore|@ts-nocheck/g,
+      message: 'Avoid TypeScript suppression comments in committed code.',
+    },
+    {
+      rule: 'double-assertion',
+      pattern: /\bas\s+unknown\s+as\b|\bas\s+any\s+as\b/g,
+      message: 'Avoid double assertions; model the type properly or add a real narrowing step.',
+      allowInTests: true,
+    },
+    {
+      rule: 'explicit-any',
+      pattern:
+        /:\s*any\b|\bas\s+any\b|<\s*any\s*>|\bArray<\s*any\s*>|\bPromise<\s*any\s*>|\bRecord<[^>\n]*\bany\b/g,
+      message: 'Avoid explicit any; prefer precise types or unknown plus narrowing.',
+      allowInTests: true,
+    },
+    {
+      rule: 'todo-markers',
+      pattern: /\bTODO\b|\bFIXME\b|\bHACK\b/g,
+      message: 'Resolve or remove TODO/FIXME/HACK markers before committing.',
+    },
+  ];
+
+  for (const rule of failPatterns) {
+    if (isTestFile && rule.allowInTests) {
+      continue;
+    }
+    for (const match of collectMatches(content, rule.pattern)) {
+      failures.push({
+        file: file.relativePath,
+        line: match.line,
+        rule: rule.rule,
+        message: rule.message,
+      });
+    }
+  }
+
+  if (isPackageSource) {
+    for (const match of collectMatches(
+      content,
+      /^\s*(?:import|export)\s.+from\s+['"](\.{1,2}\/[^'"]*)['"]/gm,
+    )) {
+      failures.push({
+        file: file.relativePath,
+        line: match.line,
+        rule: 'relative-import',
+        message: 'Use the package root alias instead of relative imports inside package source.',
+      });
+    }
+
+    for (const match of collectMatches(content, /^\s*export\s+default\b/gm)) {
+      failures.push({
+        file: file.relativePath,
+        line: match.line,
+        rule: 'default-export',
+        message: 'Prefer named exports in package source files.',
+      });
+    }
+  }
+
+  if (lineCount > LARGE_FILE_WARNING_LINES) {
+    warnings.push({
+      file: file.relativePath,
+      line: 1,
+      rule: 'large-file',
+      message: `File has ${lineCount} lines; consider splitting responsibilities before it grows further.`,
+    });
+  }
+
+  const exportCount = collectMatches(content, /^\s*export\b/gm).length;
+  if (exportCount > MANY_EXPORTS_WARNING_COUNT) {
+    warnings.push({
+      file: file.relativePath,
+      line: 1,
+      rule: 'many-exports',
+      message: `File exports ${exportCount} symbols; consider shrinking the public surface or splitting the module.`,
+    });
+  }
+
+  for (const match of collectMatches(content, /\?.*\?.*:.*:/g)) {
+    warnings.push({
+      file: file.relativePath,
+      line: match.line,
+      rule: 'nested-ternary',
+      message: 'Nested ternaries make intent harder to follow; prefer explicit branching.',
+    });
+  }
+
+  for (const match of collectMatches(
+    content,
+    /catch\s*(?:\([^)]*\))?\s*\{\s*(?:\/\/[^\n]*\n\s*|\/\*[\s\S]*?\*\/\s*)*\}/g,
+  )) {
+    warnings.push({
+      file: file.relativePath,
+      line: match.line,
+      rule: 'empty-catch',
+      message: 'Empty catch blocks hide failure paths; document why they are safe or surface the error.',
+    });
+  }
+
+  return { failures, warnings };
+}
+
+function formatIssue(issue) {
+  return `- ${issue.file}:${issue.line} [${issue.rule}] ${issue.message}`;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const requestedFiles =
+  args.files.length > 0 ? args.files.map(normalizeFileInput).filter(Boolean) : getStagedTypeScriptFiles().map(normalizeFileInput);
+
+if (requestedFiles.length === 0) {
+  console.log('TypeScript guideline check: no matching files to inspect.');
+  process.exit(0);
+}
+
+const failures = [];
+const warnings = [];
+
+for (const file of requestedFiles) {
+  const content = readFileContent(file, args.useStaged);
+  const result = inspectFile(file, content);
+  failures.push(...result.failures);
+  warnings.push(...result.warnings);
+}
+
+if (warnings.length > 0) {
+  console.warn('TypeScript guideline warnings:');
+  for (const warning of warnings) {
+    console.warn(formatIssue(warning));
+  }
+}
+
+if (failures.length > 0) {
+  console.error('TypeScript guideline check failed:');
+  for (const failure of failures) {
+    console.error(formatIssue(failure));
+  }
+  process.exit(1);
+}
+
+console.log(
+  `TypeScript guideline check passed for ${requestedFiles.length} file${
+    requestedFiles.length === 1 ? '' : 's'
+  }.`,
+);

--- a/scripts/check-typescript-guidelines.mjs
+++ b/scripts/check-typescript-guidelines.mjs
@@ -49,7 +49,15 @@ function parseArgs(argv) {
 }
 
 function getStagedTypeScriptFiles() {
-  const output = gitInRepo(['diff', '--cached', '--name-only', '--diff-filter=ACMR', '--', '*.ts', '*.tsx']);
+  const output = gitInRepo([
+    'diff',
+    '--cached',
+    '--name-only',
+    '--diff-filter=ACMR',
+    '--',
+    '*.ts',
+    '*.tsx',
+  ]);
   return output
     .split('\n')
     .map((value) => value.trim())
@@ -203,7 +211,8 @@ function inspectFile(file, content) {
       file: file.relativePath,
       line: match.line,
       rule: 'empty-catch',
-      message: 'Empty catch blocks hide failure paths; document why they are safe or surface the error.',
+      message:
+        'Empty catch blocks hide failure paths; document why they are safe or surface the error.',
     });
   }
 
@@ -216,7 +225,9 @@ function formatIssue(issue) {
 
 const args = parseArgs(process.argv.slice(2));
 const requestedFiles =
-  args.files.length > 0 ? args.files.map(normalizeFileInput).filter(Boolean) : getStagedTypeScriptFiles().map(normalizeFileInput);
+  args.files.length > 0
+    ? args.files.map(normalizeFileInput).filter(Boolean)
+    : getStagedTypeScriptFiles().map(normalizeFileInput);
 
 if (requestedFiles.length === 0) {
   console.log('TypeScript guideline check: no matching files to inspect.');


### PR DESCRIPTION
## Summary

Replaces DOM scraping with a direct HTTP client for Teams data fetching. Playwright is now only used for auth bootstrap — actual chat list and message retrieval goes through plain HTTP calls.

### What's new

- **Token extraction**: `extractTeamsTokensFromMsalCache()` reads 3 audience-specific bearer tokens from MSAL localStorage cache
- **Response parsers**: `parseTeamsChatListResponse()` and `parseTeamsMessagesResponse()` normalize raw Teams API JSON into typed domain objects  
- **HTTP client functions**: `fetchTeamsAuthzBootstrap()`, `fetchTeamsChatList()`, `fetchTeamsMessages()` — injectable fetch for testability
- **Orchestrators**: `listTeamsDirect()` and `readTeamsDirect()` compose bootstrap + fetch + parse
- **Seamless integration**: `listTeams()`/`readTeams()` try direct HTTP first, fall back to DOM scraping when MSAL tokens unavailable
- **Browser bridge**: `extractTeamsTokensFromPage()` uses `page.evaluate()` to read localStorage

### Testing

- 26 new tests (67 total in suite), all TDD
- Full `pnpm verify` green (format, lint, build, test)
- Manual test script included for live testing