### PR TITLE
feat: add weekly summary workflow and Confluence tooling

### DIFF
--- a/.agents/skills/weekly-work-summary/SKILL.md
+++ b/.agents/skills/weekly-work-summary/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: weekly-work-summary
+description: Use when preparing or publishing a weekly work summary page from workplace systems and Copilot activity, especially when the report must gather evidence across Teams, Jira, Confluence, and Copilot sessions for the current work week.
+---
+
+# Weekly Work Summary
+
+## Overview
+
+Build one evidence-backed weekly summary page for the current work week. Treat this skill as the workflow contract: follow the required inputs, source order, failure rules, collection steps, deduplication rules, and publishing target exactly.
+
+Never invent evidence, outcomes, or completion claims. If a source cannot be reached, stop the workflow and report the blocking failure instead of producing a polished partial summary.
+
+## When to Use
+
+Use this skill when the task is to prepare or publish a weekly work summary from workplace evidence.
+
+- Use it when the summary must cover the current work week.
+- Use it when evidence must be gathered across Teams, Jira, Confluence, and Copilot sessions.
+- Use it when the summary will be published to the weekly summary parent page or prepared in that publish-ready format.
+
+Do not use this skill for ad hoc status notes, one-source summaries, or rolling-window activity reports unless the caller explicitly changes the contract.
+
+## Scope
+
+This skill covers:
+
+- deriving the calendar-week window,
+- collecting evidence in the required source order,
+- deduplicating overlapping items,
+- drafting the summary in the required page structure,
+- publishing only when the selected execution mode allows it.
+
+This skill does not allow invented evidence, soft-failed collection, or publishing a partial page after a required collector fails.
+
+## Required Inputs
+
+Capture these inputs before collecting evidence:
+
+| Input          | Requirement                                                                                                                           | Default                                            |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Date           | Use today's local date for the page title and week boundary calculation.                                                              | Today                                              |
+| Parent page    | Publish under the weekly summary parent page.                                                                                         | `https://newdaycards.atlassian.net/wiki/x/DQFHbwE` |
+| Time window    | Calendar week only, not rolling days.                                                                                                 | Monday-to-today                                    |
+| Summary style  | Choose the narrative detail level for the final write-up.                                                                             | Balanced output                                    |
+| Execution mode | Accepted values: `Full auto publish` or `Draft only`. Use `Draft only` to stop before publish and return the gathered draft/evidence. | Full auto publish                                  |
+
+If the caller does not override the inputs above, use those defaults exactly.
+
+Default synthesis behavior is balanced output unless the caller explicitly asks for a shorter or more detailed summary.
+
+## Source Order
+
+Collect and synthesize evidence in this order, and do not reorder it during analysis:
+
+1. Teams
+2. Jira
+3. Confluence
+4. Copilot sessions
+
+Use earlier sources to anchor what happened and later sources to fill gaps or add implementation detail. Do not let Copilot or git-style implementation detail lead the narrative when stronger workplace evidence exists upstream.
+
+## Hard Failure Rules
+
+Stop immediately and report a hard failure when any required authentication, CLI, API, or database access is missing or unavailable.
+
+- Do not soft-fail.
+- Do not publish a partial page.
+- Do not write a polished narrative around incomplete evidence.
+- Do not guess what missing sources would have shown.
+
+Examples of hard failures:
+
+- Teams export requires authentication and the browser session is invalid.
+- Jira CLI access is unavailable.
+- Confluence CLI or API access is unavailable.
+- `session_store` cannot be queried for Copilot activity.
+- The publish target cannot be opened or updated.
+
+## Collection Workflow
+
+### 1. Derive the time window
+
+Derive the calendar week automatically:
+
+- Find the Monday for today's local date.
+- Use Monday through today inclusive.
+- Never substitute a rolling 7-day window unless the caller explicitly overrides the time window.
+
+### 2. Collect evidence in source order
+
+#### Teams
+
+Run:
+
+```bash
+clawpilot-browser teams export --since <monday> --json
+```
+
+Use Teams as the primary activity anchor for meetings, call follow-ups, decisions, coordination, and shared progress updates.
+
+#### Jira
+
+Query the Jira CLI for tickets touched during the same Monday-to-today window. Prefer issues with explicit evidence of progress such as status changes, comments, worklogs, transitions, or updated fields.
+
+#### Confluence
+
+Query the Confluence CLI or API for pages touched during the same Monday-to-today window. Prefer pages you edited, commented on, or materially advanced.
+
+#### Copilot sessions
+
+Query `session_store` for Copilot work during the same Monday-to-today window. Use it to recover implementation detail, commands, files, branches, or checkpoints that support the story from workplace systems.
+
+### 3. Validate and deduplicate
+
+Deduplicate overlapping evidence before writing the summary:
+
+- Merge the same work item seen in Teams, Jira, Confluence, and Copilot into one activity.
+- Prefer the strongest evidence source in the required order.
+- Keep supporting links from secondary sources in the appendix instead of counting them as separate accomplishments.
+- Avoid double-counting a ticket, meeting, or document that appears in multiple systems.
+
+### 4. Synthesize conservatively
+
+Default to balanced output:
+
+- Summarize the week in a concise narrative, with enough detail to be useful but without raw dumps.
+- Prefer links, ticket ids, page ids, chat ids, and session ids over pasted transcripts or large payloads.
+- Only claim outcomes that the collected evidence supports.
+- If the evidence is ambiguous, describe the work neutrally instead of overstating impact.
+
+### 5. Publish
+
+Execution mode controls the final step. Accepted values are `Full auto publish` and `Draft only`.
+
+- `Full auto publish`: publish the final page under `https://newdaycards.atlassian.net/wiki/x/DQFHbwE`.
+- `Draft only`: stop before publish and return the gathered draft plus evidence appendix for review instead of updating Confluence.
+
+Use the structure from `references/page-template.md`. Use the evidence checks from `references/source-checklist.md` before publishing or returning the draft.
+
+## Evidence Rules
+
+- Never invent evidence.
+- Never infer completion from intent alone.
+- Never convert tentative discussion into shipped work.
+- Never turn a draft, TODO, or exploration session into a finished result without corroboration.
+- Prefer links and ids over raw dumps.
+- Keep raw source material out of the narrative unless a short quote is essential.
+
+## Output Contract
+
+The final page must include:
+
+- A title using today's date.
+- A narrative summary section.
+- An evidence appendix grouped by Teams, Jira, Confluence, and Copilot.
+- An explicit missing-source section if any collector fails before publish.
+
+If any required collector fails, report the failure and do not publish.
+
+## References
+
+- Source checks: `references/source-checklist.md`
+- Page structure: `references/page-template.md`
+
+## Common Mistakes
+
+| Mistake                                | Required behavior                                                     |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| Using the last 7 days                  | Always derive Monday-to-today unless the caller overrides the window. |
+| Letting Copilot lead the story         | Use Teams, then Jira, then Confluence, then Copilot sessions.         |
+| Soft-failing on missing auth/tools     | Treat missing auth or unavailable tooling as a hard failure and stop. |
+| Counting the same work twice           | Merge overlapping evidence into one activity with source links.       |
+| Writing confident claims without proof | Keep only evidence-backed statements and note ambiguity honestly.     |

--- a/.agents/skills/weekly-work-summary/references/page-template.md
+++ b/.agents/skills/weekly-work-summary/references/page-template.md
@@ -1,0 +1,53 @@
+# Weekly Work Summary Page Template
+
+## Title
+
+`Weekly work summary - YYYY-MM-DD`
+
+Use today's local date in the title.
+
+## Narrative Summary
+
+Write a balanced summary of the week using one short intro paragraph and a concise bullet list of the main work items.
+
+Suggested structure:
+
+- One sentence stating the Monday-to-today window.
+- One paragraph summarizing the main themes, decisions, delivery, and coordination.
+- Three to seven bullets covering the most evidence-backed work items.
+
+Each bullet should:
+
+- describe one deduplicated work item,
+- stay factual and conservative,
+- mention the strongest supporting id or link inline when useful.
+
+## Evidence Appendix
+
+### Teams
+
+- `chat/channel/thread id` - short evidence note - link
+- `chat/channel/thread id` - short evidence note - link
+
+### Jira
+
+- `TICKET-123` - short evidence note - link
+- `TICKET-456` - short evidence note - link
+
+### Confluence
+
+- `page title (page id)` - short evidence note - link
+- `page title (page id)` - short evidence note - link
+
+### Copilot
+
+- `session id` - short evidence note including files, branch, or command detail - link or reference
+- `session id` - short evidence note including files, branch, or command detail - link or reference
+
+## Missing Sources
+
+Include this section if any collector fails or is unavailable.
+
+- `Source name` - why collection failed - whether publish was blocked
+
+If any required source fails before publish, keep this section in the draft report and stop instead of publishing a polished partial page.

--- a/.agents/skills/weekly-work-summary/references/source-checklist.md
+++ b/.agents/skills/weekly-work-summary/references/source-checklist.md
@@ -1,0 +1,51 @@
+# Source Checklist
+
+Use this checklist before synthesis. Capture concrete evidence, not impressions.
+
+## Teams
+
+- Confirm Teams access is authenticated before export.
+- Export activity for the derived Monday-to-today window with `clawpilot-browser teams export --since <monday> --json`.
+- Record the chat id, channel id, or meeting thread id for each item used.
+- Capture message permalinks or thread links when available.
+- Note meeting titles, thread topics, timestamps, and participants only when they directly support the summary.
+- Mark whether the item shows coordination, decision-making, status reporting, or follow-up actions.
+- Exclude casual chatter that does not support a work claim.
+
+## Jira
+
+- Confirm Jira CLI access works before collecting issues.
+- List tickets touched in the Monday-to-today window.
+- Record the ticket key for each item used.
+- Capture evidence type for each ticket: transition, comment, worklog, assignee change, field update, or linked PR/update.
+- Keep direct links to the issue and, where possible, the specific activity that proves it was touched this week.
+- Note the current status only if it is relevant to the summary.
+- Do not treat ticket assignment alone as proof of substantive work.
+
+## Confluence
+
+- Confirm Confluence CLI or API access works before collecting pages.
+- List pages touched in the Monday-to-today window.
+- Record the page title and page id for each item used.
+- Capture direct page links and note whether the evidence is an edit, comment, new page, or material revision.
+- Keep a short note about what changed only when it is visible from the page history or page content.
+- Do not count passive page views or unchanged drafts as work evidence.
+
+## Copilot Sessions
+
+- Confirm `session_store` is queryable before collecting Copilot evidence.
+- Query sessions in the same Monday-to-today window.
+- Record the session id for each item used.
+- Capture concrete artifacts such as changed file paths, branch names, PR refs, commands, checkpoints, or explicit task summaries.
+- Link Copilot evidence back to the Teams, Jira, or Confluence item it supports whenever possible.
+- Use Copilot to add implementation detail, not to replace stronger workplace evidence.
+- Do not claim outcomes that appear only as plans, drafts, or assistant speculation.
+
+## Cross-Source Deduplication
+
+- Group evidence by underlying work item before writing.
+- Merge the same work across sources into one summary point.
+- Prefer source authority in this order: Teams, Jira, Confluence, Copilot sessions.
+- Keep secondary-source links in the appendix instead of duplicating the accomplishment in the narrative.
+- If two sources disagree, keep the claim at the lowest evidence-backed level and note the ambiguity.
+- If a source is missing, report it explicitly instead of filling the gap with inference.

--- a/.github/extensions/weekly-work-summary/extension.mjs
+++ b/.github/extensions/weekly-work-summary/extension.mjs
@@ -1,0 +1,237 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { joinSession } from '@github/copilot-sdk/extension';
+
+const COMMAND_NAMES = new Set(['/weekly-work-summary', 'weekly-work-summary']);
+const DEFAULT_PARENT_PAGE = 'https://newdaycards.atlassian.net/wiki/x/DQFHbwE';
+const DEFAULT_TIME_WINDOW = 'Monday-to-today';
+const DEFAULT_SUMMARY_STYLE = 'Balanced output';
+const DEFAULT_EXECUTION_MODE = 'Full auto publish';
+const VALID_EXECUTION_MODES = new Map([
+  ['full auto publish', 'Full auto publish'],
+  ['draft only', 'Draft only'],
+]);
+
+const EXTENSION_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(EXTENSION_DIR, '../../..');
+const SKILL_PATH = path.join(REPO_ROOT, '.agents/skills/weekly-work-summary/SKILL.md');
+const SOURCE_CHECKLIST_PATH = path.join(
+  REPO_ROOT,
+  '.agents/skills/weekly-work-summary/references/source-checklist.md',
+);
+const PAGE_TEMPLATE_PATH = path.join(
+  REPO_ROOT,
+  '.agents/skills/weekly-work-summary/references/page-template.md',
+);
+
+let cachedWorkflowContextPromise;
+
+const session = await joinSession({
+  hooks: {
+    onSessionStart: async () => {
+      await session.log('weekly-work-summary extension loaded', { ephemeral: true });
+    },
+    onUserPromptSubmitted: async (input) => {
+      const parsed = parseWeeklyWorkSummaryCommand(input.prompt);
+      if (!parsed) {
+        return;
+      }
+
+      await session.log('Intercepted weekly-work-summary command', { ephemeral: true });
+
+      if (parsed.kind === 'help') {
+        return {
+          modifiedPrompt: buildHelpPrompt(),
+          additionalContext: await loadWorkflowContext(),
+        };
+      }
+
+      if (parsed.kind === 'error') {
+        return {
+          modifiedPrompt: buildUsageErrorPrompt(parsed.message),
+          additionalContext: await loadWorkflowContext(),
+        };
+      }
+
+      return {
+        modifiedPrompt: buildWorkflowPrompt(parsed),
+        additionalContext: await loadWorkflowContext(),
+      };
+    },
+  },
+  tools: [],
+});
+
+function parseWeeklyWorkSummaryCommand(prompt) {
+  const tokens = tokenize(prompt.trim());
+  if (tokens.length === 0 || !COMMAND_NAMES.has(tokens[0])) {
+    return null;
+  }
+
+  const options = {
+    date: 'Today',
+    parentPage: DEFAULT_PARENT_PAGE,
+    timeWindow: DEFAULT_TIME_WINDOW,
+    summaryStyle: DEFAULT_SUMMARY_STYLE,
+    executionMode: DEFAULT_EXECUTION_MODE,
+    operatorNote: '',
+  };
+  const notes = [];
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (token === '--help' || token === '-h') {
+      return { kind: 'help' };
+    }
+
+    if (!token.startsWith('--')) {
+      notes.push(token);
+      continue;
+    }
+
+    const parsedFlag = parseFlag(token, tokens[index + 1]);
+    if (!parsedFlag.ok) {
+      return { kind: 'error', message: parsedFlag.message };
+    }
+
+    if (parsedFlag.consumedNextToken) {
+      index += 1;
+    }
+
+    switch (parsedFlag.name) {
+      case 'date':
+        options.date = parsedFlag.value;
+        break;
+      case 'parent-page':
+        options.parentPage = parsedFlag.value;
+        break;
+      case 'time-window':
+        options.timeWindow = parsedFlag.value;
+        break;
+      case 'summary-style':
+        options.summaryStyle = parsedFlag.value;
+        break;
+      case 'mode': {
+        const normalizedMode = VALID_EXECUTION_MODES.get(parsedFlag.value.trim().toLowerCase());
+        if (!normalizedMode) {
+          return {
+            kind: 'error',
+            message:
+              'Invalid `--mode` value. Use `Full auto publish` or `Draft only` (quote values that contain spaces).',
+          };
+        }
+        options.executionMode = normalizedMode;
+        break;
+      }
+      case 'draft-only':
+        options.executionMode = 'Draft only';
+        break;
+      default:
+        return {
+          kind: 'error',
+          message: `Unknown flag \`${parsedFlag.rawName}\`. Run \`/weekly-work-summary --help\` for usage.`,
+        };
+    }
+  }
+
+  options.operatorNote = notes.join(' ').trim();
+  return { kind: 'command', ...options };
+}
+
+function parseFlag(token, nextToken) {
+  const [rawName, inlineValue] = token.split(/=(.*)/s, 2);
+  const name = rawName.replace(/^--/, '');
+
+  if (name === 'draft-only') {
+    return { ok: true, name, value: 'true', consumedNextToken: false, rawName };
+  }
+
+  const value = inlineValue ?? nextToken;
+  if (!value || value.startsWith('--')) {
+    return {
+      ok: false,
+      message: `Flag \`${rawName}\` requires a value.`,
+    };
+  }
+
+  return { ok: true, name, value, consumedNextToken: inlineValue === undefined, rawName };
+}
+
+function tokenize(prompt) {
+  const tokens = [];
+  const matcher = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|[^\s]+/g;
+
+  for (const match of prompt.matchAll(matcher)) {
+    tokens.push(match[1] ?? match[2] ?? match[0]);
+  }
+
+  return tokens;
+}
+
+function buildHelpPrompt() {
+  return [
+    'Explain how to use the repo-local `/weekly-work-summary` command in this repository.',
+    'Include supported flags, defaults, and at least two concrete examples.',
+    'Cover these inputs explicitly: `--date`, `--parent-page`, `--time-window`, `--summary-style`, `--mode`, and `--draft-only`.',
+    'State that the wrapper forwards into the repo-local weekly-work-summary workflow contract and that `--mode` accepts `Full auto publish` or `Draft only`.',
+  ].join(' ');
+}
+
+function buildUsageErrorPrompt(message) {
+  return [
+    `The repo-local weekly-work-summary command was invoked incorrectly: ${message}`,
+    'Explain the correct usage briefly, then show one full-auto example and one draft-only example.',
+  ].join(' ');
+}
+
+function buildWorkflowPrompt(parsed) {
+  const lines = [
+    'Run the repo-local weekly work summary workflow for this repository.',
+    'Use the injected weekly-work-summary contract and references as the authoritative workflow specification.',
+    '',
+    'Explicit inputs:',
+    `- Date: ${parsed.date}`,
+    `- Parent page: ${parsed.parentPage}`,
+    `- Time window: ${parsed.timeWindow}`,
+    `- Summary style: ${parsed.summaryStyle}`,
+    `- Execution mode: ${parsed.executionMode}`,
+  ];
+
+  if (parsed.operatorNote) {
+    lines.push(`- Operator note: ${parsed.operatorNote}`);
+  }
+
+  lines.push(
+    '',
+    'Follow the source order, hard-failure rules, deduplication rules, and publishing behavior from the injected contract exactly.',
+    'If execution mode is `Draft only`, stop before publish and return the gathered draft plus evidence appendix.',
+    'If execution mode is `Full auto publish`, complete the publish step under the specified parent page.',
+  );
+
+  return lines.join('\n');
+}
+
+async function loadWorkflowContext() {
+  cachedWorkflowContextPromise ??= Promise.all([
+    readFile(SKILL_PATH, 'utf8'),
+    readFile(SOURCE_CHECKLIST_PATH, 'utf8'),
+    readFile(PAGE_TEMPLATE_PATH, 'utf8'),
+  ]).then(([skill, checklist, template]) =>
+    [
+      'Repo-local weekly work summary workflow contract. Treat these files as the source of truth for the command wrapper.',
+      '',
+      `--- ${path.relative(REPO_ROOT, SKILL_PATH)} ---`,
+      skill,
+      '',
+      `--- ${path.relative(REPO_ROOT, SOURCE_CHECKLIST_PATH)} ---`,
+      checklist,
+      '',
+      `--- ${path.relative(REPO_ROOT, PAGE_TEMPLATE_PATH)} ---`,
+      template,
+    ].join('\n'),
+  );
+
+  return cachedWorkflowContextPromise;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .DS_Store
 test-results.json
 coverage/
+.worktrees/
+.agents/notes.md

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pnpm exec clawpilot-browser auth status
 pnpm exec clawpilot-browser auth clear
 ```
 
-`pnpm browser:install` builds `@clawpilot/browser` and installs the Playwright Chromium binary used by the health checks. After that, invoke the repo-local CLI with `pnpm exec clawpilot-browser ...` from the repository root.
+`pnpm browser:install` builds `@clawpilot/browser` and installs the Playwright browser binaries required by the health checks. After that, invoke the repo-local CLI with `pnpm exec clawpilot-browser ...` from the repository root.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ pnpm exec clawpilot-browser teams list [--limit 20] [--offset 0] [--json]
 # Read a specific Teams chat/channel by id from `teams list`
 pnpm exec clawpilot-browser teams read "<id>" [--limit 20] [--offset 0] [--json]
 
+# Look up a Confluence page by URL or page id
+pnpm exec clawpilot-browser confluence page get "<page-id-or-url>" [--json]
+
+# Create a Confluence child page under a parent page
+pnpm exec clawpilot-browser confluence page create-child "<parent-page-id-or-url>" --title "Weekly work summary - YYYY-MM-DD" --body "<p>Body</p>" [--json]
+
+# Update a Confluence page title and/or body
+pnpm exec clawpilot-browser confluence page update "<page-id-or-url>" [--title "New title"] [--body "<p>Updated body</p>"] [--json]
+
 # Validate whether the saved Office session still works
 pnpm exec clawpilot-browser auth status --validate
 
@@ -106,6 +115,10 @@ packages/clawpilot-browser/scripts/manual-test-teams.sh
 session expiry hints plus the last live validation timestamp/result. Expiry remains
 best-effort because some Microsoft cookies are session-only or can be invalidated
 server-side before their cookie expiry.
+
+Confluence commands reuse the existing Atlassian site and token setup from `JIRA_URL`,
+`JIRA_API_TOKEN`, and the jira-cli login config by default. Override with
+`CONFLUENCE_SITE_URL`, `CONFLUENCE_API_TOKEN`, or `CONFLUENCE_LOGIN` if needed.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -30,31 +30,29 @@ Clawpilot is a self-improving personal AI agent. It runs as a daemon on your lap
 # Install dependencies
 pnpm install
 
-# Install Playwright browser
-npx playwright install chromium
-
-# Build browser CLI
-cd packages/clawpilot-browser
-pnpm build
+# Prepare the repo-local browser CLI
+pnpm browser:install
 
 # Check Playwright installation
-node dist/index.js health check-install
+pnpm exec clawpilot-browser health check-install
 
 # Check session status
-node dist/index.js health check-session
+pnpm exec clawpilot-browser health check-session
 
 # Full health check
-node dist/index.js health full
+pnpm exec clawpilot-browser health full
 
 # Login to Office 365 (opens a browser window)
-node dist/index.js auth login
+pnpm exec clawpilot-browser auth login
 
 # Verify login
-node dist/index.js auth status
+pnpm exec clawpilot-browser auth status
 
 # Clear session
-node dist/index.js auth clear
+pnpm exec clawpilot-browser auth clear
 ```
+
+`pnpm browser:install` builds `@clawpilot/browser` and installs the Playwright Chromium binary used by the health checks. After that, invoke the repo-local CLI with `pnpm exec clawpilot-browser ...` from the repository root.
 
 ## Development
 
@@ -83,19 +81,19 @@ The pre-commit hook runs `lint-staged` plus a staged-file guideline check for ch
 
 ```bash
 # Search the web using DuckDuckGo
-node packages/clawpilot-browser/dist/index.js web search "your query" [--max-results 5]
+pnpm exec clawpilot-browser web search "your query" [--max-results 5]
 
 # Fetch and extract content from a URL
-node packages/clawpilot-browser/dist/index.js web fetch "https://example.com" [--readability]
+pnpm exec clawpilot-browser web fetch "https://example.com" [--readability]
 
 # List Teams chats and channels (default page size: 20)
-node packages/clawpilot-browser/dist/index.js teams list [--limit 20] [--offset 0] [--json]
+pnpm exec clawpilot-browser teams list [--limit 20] [--offset 0] [--json]
 
 # Read a specific Teams chat/channel by id from `teams list`
-node packages/clawpilot-browser/dist/index.js teams read "<id>" [--limit 20] [--offset 0] [--json]
+pnpm exec clawpilot-browser teams read "<id>" [--limit 20] [--offset 0] [--json]
 
 # Validate whether the saved Office session still works
-node packages/clawpilot-browser/dist/index.js auth status --validate
+pnpm exec clawpilot-browser auth status --validate
 
 # Run the end-to-end manual browser QA script
 packages/clawpilot-browser/scripts/manual-test-web.sh

--- a/docs/plans/2026-03-28-weekly-work-summary-workflow.md
+++ b/docs/plans/2026-03-28-weekly-work-summary-workflow.md
@@ -1,0 +1,325 @@
+# Weekly Work Summary Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a repo-local weekly work summary workflow that gathers Monday-to-today activity from Teams, Jira, Confluence, and Copilot sessions, synthesizes a balanced summary, and publishes a dated Confluence page under the configured parent.
+
+**Architecture:** Ship the first version as a project-local skill so the workflow can orchestrate existing tools without waiting on a new runtime. Strengthen the weakest source primitive first by adding a date-bounded Teams export command in `@clawpilot/browser`, then encode the end-to-end workflow in `.agents/skills/weekly-work-summary`. After the skill works reliably, add a thin repo-local extension that exposes a stable command surface but reuses the same workflow contract and avoids duplicating the source-specific rules.
+
+**Tech Stack:** Project-local Copilot skill markdown, Copilot CLI extension, `@clawpilot/browser` Teams CLI, Jira CLI, Confluence CLI/API, Copilot `session_store` SQL, TypeScript, Commander, Vitest
+
+---
+
+### Task 1: Add a date-bounded Teams export primitive
+
+**Files:**
+
+- Modify: `packages/clawpilot-browser/src/teams.ts`
+- Modify: `packages/clawpilot-browser/src/commands/teams.ts`
+- Modify: `packages/clawpilot-browser/src/__tests__/teams.test.ts`
+- Modify: `packages/clawpilot-browser/src/__tests__/teams-command.test.ts`
+- Modify: `README.md`
+
+**Step 1: Write the failing domain tests**
+
+Add focused tests in `packages/clawpilot-browser/src/__tests__/teams.test.ts` for a new export helper that:
+
+- accepts a `since` ISO date
+- keeps only conversations with activity on or after `since`
+- preserves direct chats, private/group chats, and channels in one normalized result
+- returns stable JSON fields the workflow can summarize later
+
+**Step 2: Run the targeted Teams tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @clawpilot/browser test -- src/__tests__/teams.test.ts src/__tests__/teams-command.test.ts
+```
+
+Expected: FAIL because the export helper and command do not exist yet.
+
+**Step 3: Implement the minimal Teams export logic**
+
+In `packages/clawpilot-browser/src/teams.ts`, add a narrow helper such as `exportTeamsActivity()` that builds on the existing list/read primitives instead of duplicating fetch logic. Keep the output normalized and JSON-friendly so the workflow can group by conversation type and timestamp without screen-scraping.
+
+**Step 4: Add a CLI subcommand**
+
+In `packages/clawpilot-browser/src/commands/teams.ts`, add a new subcommand such as:
+
+```bash
+clawpilot-browser teams export --since 2026-03-23 --json
+```
+
+The command should:
+
+- require `--since`
+- default to JSON output for machine consumption
+- keep the human-readable formatter thin if a text mode is added later
+
+**Step 5: Update command tests**
+
+Extend `packages/clawpilot-browser/src/__tests__/teams-command.test.ts` so the new command:
+
+- parses `--since`
+- prints JSON output
+- forwards arguments into the domain helper
+- surfaces errors without swallowing them
+
+**Step 6: Run the targeted Teams tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @clawpilot/browser test -- src/__tests__/teams.test.ts src/__tests__/teams-command.test.ts
+```
+
+Expected: PASS for the new export coverage.
+
+**Step 7: Update usage docs**
+
+Add the new Teams export command to `README.md` near the existing `teams list` / `teams read` examples.
+
+**Step 8: Commit**
+
+```bash
+git add README.md packages/clawpilot-browser/src/teams.ts packages/clawpilot-browser/src/commands/teams.ts packages/clawpilot-browser/src/__tests__/teams.test.ts packages/clawpilot-browser/src/__tests__/teams-command.test.ts
+git commit -m "feat: add Teams activity export command
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: Add the repo-local weekly summary skill
+
+**Files:**
+
+- Create: `.agents/skills/weekly-work-summary/SKILL.md`
+- Create: `.agents/skills/weekly-work-summary/references/source-checklist.md`
+- Create: `.agents/skills/weekly-work-summary/references/page-template.md`
+- Modify: `README.md`
+
+**Step 1: Write the skill contract before workflow prose**
+
+Create `SKILL.md` with:
+
+- name, description, triggers, and scope metadata
+- required inputs: date, parent page, time window, execution mode
+- explicit source order: Teams, Jira, Confluence, Copilot sessions
+- hard failure rule for missing auth or unavailable tools
+
+Keep the skill as the single source of truth for the workflow contract.
+
+**Step 2: Add the source checklist reference**
+
+Create `.agents/skills/weekly-work-summary/references/source-checklist.md` with a concrete evidence checklist for each system:
+
+- Teams: direct chats, group/private chats, channels, timestamps, links/ids
+- Jira: assigned, updated, commented, transitioned tickets
+- Confluence: created, edited, commented pages
+- Copilot sessions: summary, files touched, refs, notable tasks
+
+This reference should tell the executor what to collect, not how to improvise.
+
+**Step 3: Add the page template reference**
+
+Create `.agents/skills/weekly-work-summary/references/page-template.md` with the expected output structure:
+
+- page title using today’s date
+- narrative summary section
+- evidence appendix grouped by Teams, Jira, Confluence, and Copilot
+- explicit missing-source section if any collector fails
+
+**Step 4: Encode the end-to-end workflow in the skill**
+
+In `SKILL.md`, instruct the executor to:
+
+1. derive Monday-to-today automatically
+2. run `clawpilot-browser teams export --since <monday> --json`
+3. query Jira CLI for tickets touched this week
+4. query Confluence CLI/API for pages touched this week
+5. query `session_store` for Copilot work this week
+6. deduplicate overlapping evidence
+7. publish the final page under `https://newdaycards.atlassian.net/wiki/x/DQFHbwE`
+
+The skill should prefer links and ids over raw dumps and forbid invented evidence.
+
+**Step 5: Add a README entry for the new project-local skill**
+
+Document the skill in `README.md` near the existing project-local skill section.
+
+**Step 6: Manual smoke-check the skill text**
+
+Verify the skill can be loaded and read cleanly by checking:
+
+- file names are correct
+- references are linked correctly
+- the default behavior matches the user decisions: balanced output, calendar week, full auto
+
+**Step 7: Commit**
+
+```bash
+git add .agents/skills/weekly-work-summary README.md
+git commit -m "feat: add weekly work summary skill
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: Add a repo-local extension wrapper for command-style entry
+
+**Files:**
+
+- Create: `.github/extensions/weekly-work-summary.js`
+- Modify: `README.md`
+
+**Step 1: Inspect the Copilot extension authoring guide**
+
+Run the extension guide first and follow its recommended file shape before writing code:
+
+```bash
+# use the extensions_manage tool with operation "guide"
+```
+
+Do not invent an extension format from memory.
+
+**Step 2: Scaffold the extension**
+
+Create `.github/extensions/weekly-work-summary.js` as a thin wrapper that:
+
+- exposes a stable command-style entrypoint
+- accepts optional overrides for parent page, date, and execution mode
+- forwards into the same workflow contract as the skill
+
+Keep the wrapper thin; policy stays in the skill contract.
+
+**Step 3: Reload extensions and smoke-test discovery**
+
+Run the extension reload flow and verify the new extension appears in the loaded extension list.
+
+Expected: the extension is discoverable without runtime errors.
+
+**Step 4: Manually exercise the wrapper in draft mode**
+
+Run the extension with draft-only or dry-run inputs first and verify it:
+
+- invokes the weekly summary workflow
+- surfaces missing prerequisites clearly
+- does not silently publish on failure
+
+**Step 5: Update docs**
+
+Add a short usage example to `README.md` once the final invocation syntax is known.
+
+**Step 6: Commit**
+
+```bash
+git add .github/extensions/weekly-work-summary.js README.md
+git commit -m "feat: add weekly work summary extension
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: Verify the end-to-end weekly summary workflow
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `.agents/skills/weekly-work-summary/SKILL.md`
+- Modify: `.github/extensions/weekly-work-summary.js`
+
+**Step 1: Verify source prerequisites explicitly**
+
+Confirm each source is available before the full run:
+
+```bash
+node packages/clawpilot-browser/dist/index.js auth status --validate
+jira --version
+# run the Confluence CLI/API equivalent already configured on the machine
+```
+
+Expected: Teams session is valid, Jira is installed, and Confluence access is available.
+
+**Step 2: Run a full draft collection pass**
+
+Use the skill or wrapper to gather evidence without publishing first.
+
+Expected: one balanced summary plus an appendix with evidence grouped by source.
+
+**Step 3: Inspect the evidence for duplication and gaps**
+
+Check that:
+
+- the same ticket or page is not repeated across sections without explanation
+- Teams evidence only includes conversations with meaningful participation
+- Copilot session evidence points to concrete work, not generic session noise
+
+**Step 4: Run the publish path**
+
+Use the final full-auto mode and verify the page is created under the requested parent with today’s date in the title.
+
+Expected: the new Confluence page exists and matches the draft structure.
+
+**Step 5: Tighten wording or guardrails if verification uncovered ambiguity**
+
+Make only the smallest updates needed in the skill or extension so future runs are deterministic.
+
+**Step 6: Run repo verification**
+
+Run:
+
+```bash
+pnpm check:ts-guidelines
+pnpm lint
+pnpm build
+pnpm test
+```
+
+Expected: PASS across the repo before opening a PR.
+
+**Step 7: Commit**
+
+```bash
+git add README.md .agents/skills/weekly-work-summary .github/extensions/weekly-work-summary.js
+git commit -m "docs: finalize weekly work summary workflow
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: Open the PR and finish the branch cleanly
+
+**Files:**
+
+- No code changes expected unless review feedback requires them
+
+**Step 1: Open or update the PR**
+
+Push the branch and open a PR that explains:
+
+- why the workflow is skill-first
+- what the Teams export command adds
+- how the extension wraps the same contract
+
+**Step 2: Request Copilot review if needed**
+
+If Copilot review was not requested automatically, request it explicitly.
+
+**Step 3: Address review comments one by one**
+
+Reply to each review comment with the resolution or rationale after making any needed changes.
+
+**Step 4: Re-run verification after review changes**
+
+Run the relevant targeted tests plus:
+
+```bash
+pnpm lint && pnpm build && pnpm test
+```
+
+Expected: PASS before merge.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "A personal AI agent that runs on your laptop, learns from you, and gets things done.",
   "scripts": {
+    "browser:install": "pnpm --filter @clawpilot/browser build && pnpm --filter @clawpilot/browser exec playwright install chromium",
     "build": "pnpm -r build",
     "check:ts-guidelines": "node scripts/check-typescript-guidelines.mjs --staged",
     "test": "pnpm -r test",
@@ -27,6 +28,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@clawpilot/browser": "workspace:*",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "devDependencies": {
     "@clawpilot/browser": "workspace:*",
-    "@eslint/js": "^10.0.1",
-    "eslint": "^10.0.3",
-    "eslint-config-prettier": "^10.1.8",
-    "husky": "^9.1.7",
-    "lint-staged": "^16.4.0",
-    "prettier": "^3.8.1",
-    "typescript-eslint": "^8.57.1"
+    "@eslint/js": "10.0.1",
+    "eslint": "10.0.3",
+    "eslint-config-prettier": "10.1.8",
+    "husky": "9.1.7",
+    "lint-staged": "16.4.0",
+    "prettier": "3.8.1",
+    "typescript-eslint": "8.57.1"
   }
 }

--- a/packages/clawpilot-browser/src/__tests__/confluence-command.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/confluence-command.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+const outputMock = vi.fn();
+const successMock = vi.fn((data?: unknown) => ({ ok: true as const, data }));
+const errorMock = vi.fn((type: string, message: string) => ({
+  ok: false as const,
+  error: type,
+  message,
+}));
+const resolveConfluenceCredentialsMock = vi.fn();
+const getConfluencePageMock = vi.fn();
+const createConfluenceChildPageMock = vi.fn();
+const updateConfluencePageMock = vi.fn();
+const formatConfluencePageMock = vi.fn(() => 'formatted confluence page');
+const consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+vi.mock('@clawpilot/browser/utils/output.js', () => ({
+  output: outputMock,
+  success: successMock,
+  error: errorMock,
+}));
+
+vi.mock('@clawpilot/browser/confluence.js', () => ({
+  resolveConfluenceCredentials: resolveConfluenceCredentialsMock,
+  getConfluencePage: getConfluencePageMock,
+  createConfluenceChildPage: createConfluenceChildPageMock,
+  updateConfluencePage: updateConfluencePageMock,
+  formatConfluencePage: formatConfluencePageMock,
+}));
+
+async function createProgram(): Promise<Command> {
+  const { registerConfluenceCommands } = await import('@clawpilot/browser/commands/confluence.js');
+  const program = new Command();
+  registerConfluenceCommands(program);
+  return program;
+}
+
+describe('registerConfluenceCommands', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    outputMock.mockClear();
+    successMock.mockClear();
+    errorMock.mockClear();
+    resolveConfluenceCredentialsMock.mockReset();
+    getConfluencePageMock.mockReset();
+    createConfluenceChildPageMock.mockReset();
+    updateConfluencePageMock.mockReset();
+    formatConfluencePageMock.mockClear();
+    consoleLogMock.mockClear();
+    resolveConfluenceCredentialsMock.mockReturnValue({
+      siteBaseUrl: 'https://newdaycards.atlassian.net',
+      apiBaseUrl: 'https://newdaycards.atlassian.net/wiki/api/v2',
+      login: 'giordano.scalzo@newday.co.uk',
+      apiToken: 'jira-token',
+    });
+  });
+
+  it('prints JSON for confluence page get when requested', async () => {
+    getConfluencePageMock.mockResolvedValue({
+      id: '6161891597',
+      title: '2026',
+      status: 'current',
+      spaceId: '3210313921',
+      parentId: '5233803520',
+      versionNumber: 1,
+      body: '',
+      webUrl: 'https://newdaycards.atlassian.net/wiki/spaces/~user/pages/6161891597/2026',
+    });
+
+    const program = await createProgram();
+    await program.parseAsync(['node', 'test', 'confluence', 'page', 'get', '6161891597', '--json']);
+
+    expect(getConfluencePageMock).toHaveBeenCalledWith({
+      pageRef: '6161891597',
+      auth: expect.any(Object),
+    });
+    expect(outputMock).toHaveBeenCalledWith({
+      ok: true,
+      data: expect.objectContaining({ id: '6161891597', title: '2026' }),
+    });
+  });
+
+  it('prints human-readable output for child-page creation by default', async () => {
+    createConfluenceChildPageMock.mockResolvedValue({
+      id: '7000000001',
+      title: 'Weekly work summary - 2026-04-06',
+      status: 'current',
+      spaceId: '3210313921',
+      parentId: '6161891597',
+      versionNumber: 1,
+      body: '<p>Summary</p>',
+      webUrl:
+        'https://newdaycards.atlassian.net/wiki/spaces/~user/pages/7000000001/Weekly-work-summary-2026-04-06',
+    });
+
+    const program = await createProgram();
+    await program.parseAsync([
+      'node',
+      'test',
+      'confluence',
+      'page',
+      'create-child',
+      '6161891597',
+      '--title',
+      'Weekly work summary - 2026-04-06',
+      '--body',
+      '<p>Summary</p>',
+    ]);
+
+    expect(createConfluenceChildPageMock).toHaveBeenCalledWith({
+      parentRef: '6161891597',
+      title: 'Weekly work summary - 2026-04-06',
+      body: '<p>Summary</p>',
+      auth: expect.any(Object),
+    });
+    expect(formatConfluencePageMock).toHaveBeenCalled();
+    expect(consoleLogMock).toHaveBeenCalledWith('formatted confluence page');
+  });
+
+  it('prints JSON for page updates when requested', async () => {
+    updateConfluencePageMock.mockResolvedValue({
+      id: '7000000001',
+      title: 'Weekly work summary - 2026-04-06',
+      status: 'current',
+      spaceId: '3210313921',
+      parentId: '6161891597',
+      versionNumber: 2,
+      body: '<p>Updated</p>',
+      webUrl:
+        'https://newdaycards.atlassian.net/wiki/spaces/~user/pages/7000000001/Weekly-work-summary-2026-04-06',
+    });
+
+    const program = await createProgram();
+    await program.parseAsync([
+      'node',
+      'test',
+      'confluence',
+      'page',
+      'update',
+      '7000000001',
+      '--body',
+      '<p>Updated</p>',
+      '--json',
+    ]);
+
+    expect(updateConfluencePageMock).toHaveBeenCalledWith({
+      pageRef: '7000000001',
+      title: undefined,
+      body: '<p>Updated</p>',
+      auth: expect.any(Object),
+    });
+    expect(outputMock).toHaveBeenCalledWith({
+      ok: true,
+      data: expect.objectContaining({ id: '7000000001', versionNumber: 2 }),
+    });
+  });
+});

--- a/packages/clawpilot-browser/src/__tests__/confluence.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/confluence.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createConfluenceChildPage,
+  getConfluencePage,
+  parseConfluencePageId,
+  resolveConfluenceCredentials,
+  updateConfluencePage,
+  type ConfluenceAuth,
+  type JiraCliConfig,
+} from '@clawpilot/browser/confluence.js';
+
+function jsonResponse(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('parseConfluencePageId', () => {
+  it('accepts either a numeric page id or a Confluence page URL', () => {
+    expect(parseConfluencePageId('6161891597')).toBe('6161891597');
+    expect(
+      parseConfluencePageId(
+        'https://newdaycards.atlassian.net/wiki/spaces/~user/pages/6161891597/2026',
+      ),
+    ).toBe('6161891597');
+  });
+
+  it('returns null for unsupported refs', () => {
+    expect(parseConfluencePageId('not-a-page-ref')).toBeNull();
+  });
+});
+
+describe('resolveConfluenceCredentials', () => {
+  it('reuses Jira env credentials plus Jira CLI login details', () => {
+    const env = {
+      JIRA_URL: 'https://newdaycards.atlassian.net',
+      JIRA_API_TOKEN: 'jira-token',
+    } satisfies Partial<NodeJS.ProcessEnv>;
+    const jiraConfig: JiraCliConfig = {
+      login: 'giordano.scalzo@newday.co.uk',
+    };
+
+    expect(resolveConfluenceCredentials(env, jiraConfig)).toEqual({
+      siteBaseUrl: 'https://newdaycards.atlassian.net',
+      apiBaseUrl: 'https://newdaycards.atlassian.net/wiki/api/v2',
+      login: 'giordano.scalzo@newday.co.uk',
+      apiToken: 'jira-token',
+    });
+  });
+});
+
+describe('getConfluencePage', () => {
+  it('fetches a page by URL or id and normalizes the response', async () => {
+    const auth: ConfluenceAuth = {
+      siteBaseUrl: 'https://newdaycards.atlassian.net',
+      apiBaseUrl: 'https://newdaycards.atlassian.net/wiki/api/v2',
+      login: 'giordano.scalzo@newday.co.uk',
+      apiToken: 'jira-token',
+    };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        id: '6161891597',
+        status: 'current',
+        title: '2026',
+        spaceId: '3210313921',
+        parentId: '5233803520',
+        version: { number: 3 },
+        body: { storage: { representation: 'storage', value: '<p>Hello</p>' } },
+        _links: { webui: '/spaces/~user/pages/6161891597/2026' },
+      }),
+    );
+
+    const result = await getConfluencePage(
+      {
+        pageRef: 'https://newdaycards.atlassian.net/wiki/spaces/~user/pages/6161891597/2026',
+        auth,
+      },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://newdaycards.atlassian.net/wiki/api/v2/pages/6161891597?body-format=storage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: 'application/json',
+          authorization: expect.stringMatching(/^Basic /),
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      id: '6161891597',
+      status: 'current',
+      title: '2026',
+      spaceId: '3210313921',
+      parentId: '5233803520',
+      versionNumber: 3,
+      body: '<p>Hello</p>',
+      webUrl: 'https://newdaycards.atlassian.net/spaces/~user/pages/6161891597/2026',
+    });
+  });
+});
+
+describe('createConfluenceChildPage', () => {
+  it('looks up the parent page before creating a child page in the same space', async () => {
+    const auth: ConfluenceAuth = {
+      siteBaseUrl: 'https://newdaycards.atlassian.net',
+      apiBaseUrl: 'https://newdaycards.atlassian.net/wiki/api/v2',
+      login: 'giordano.scalzo@newday.co.uk',
+      apiToken: 'jira-token',
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: '6161891597',
+          status: 'current',
+          title: '2026',
+          spaceId: '3210313921',
+          parentId: '5233803520',
+          version: { number: 1 },
+          body: { storage: { representation: 'storage', value: '' } },
+          _links: { webui: '/spaces/~user/pages/6161891597/2026' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: '7000000001',
+          status: 'current',
+          title: 'Weekly work summary - 2026-04-06',
+          spaceId: '3210313921',
+          parentId: '6161891597',
+          version: { number: 1 },
+          body: { storage: { representation: 'storage', value: '<p>Summary</p>' } },
+          _links: { webui: '/spaces/~user/pages/7000000001/Weekly-work-summary-2026-04-06' },
+        }),
+      );
+
+    const result = await createConfluenceChildPage(
+      {
+        parentRef: '6161891597',
+        title: 'Weekly work summary - 2026-04-06',
+        body: '<p>Summary</p>',
+        auth,
+      },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://newdaycards.atlassian.net/wiki/api/v2/pages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          spaceId: '3210313921',
+          status: 'current',
+          title: 'Weekly work summary - 2026-04-06',
+          parentId: '6161891597',
+          body: {
+            representation: 'storage',
+            value: '<p>Summary</p>',
+          },
+        }),
+      }),
+    );
+    expect(result.id).toBe('7000000001');
+    expect(result.parentId).toBe('6161891597');
+  });
+});
+
+describe('updateConfluencePage', () => {
+  it('increments the page version and preserves the existing title when only the body changes', async () => {
+    const auth: ConfluenceAuth = {
+      siteBaseUrl: 'https://newdaycards.atlassian.net',
+      apiBaseUrl: 'https://newdaycards.atlassian.net/wiki/api/v2',
+      login: 'giordano.scalzo@newday.co.uk',
+      apiToken: 'jira-token',
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: '7000000001',
+          status: 'current',
+          title: 'Weekly work summary - 2026-04-06',
+          spaceId: '3210313921',
+          parentId: '6161891597',
+          version: { number: 2 },
+          body: { storage: { representation: 'storage', value: '<p>Old</p>' } },
+          _links: { webui: '/spaces/~user/pages/7000000001/Weekly-work-summary-2026-04-06' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: '7000000001',
+          status: 'current',
+          title: 'Weekly work summary - 2026-04-06',
+          spaceId: '3210313921',
+          parentId: '6161891597',
+          version: { number: 3 },
+          body: { storage: { representation: 'storage', value: '<p>New</p>' } },
+          _links: { webui: '/spaces/~user/pages/7000000001/Weekly-work-summary-2026-04-06' },
+        }),
+      );
+
+    const result = await updateConfluencePage(
+      {
+        pageRef: '7000000001',
+        body: '<p>New</p>',
+        auth,
+      },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://newdaycards.atlassian.net/wiki/api/v2/pages/7000000001',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          id: '7000000001',
+          status: 'current',
+          title: 'Weekly work summary - 2026-04-06',
+          spaceId: '3210313921',
+          parentId: '6161891597',
+          body: {
+            representation: 'storage',
+            value: '<p>New</p>',
+          },
+          version: {
+            number: 3,
+          },
+        }),
+      }),
+    );
+    expect(result.versionNumber).toBe(3);
+    expect(result.body).toBe('<p>New</p>');
+  });
+});

--- a/packages/clawpilot-browser/src/__tests__/teams-command.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams-command.test.ts
@@ -10,8 +10,10 @@ const errorMock = vi.fn((type: string, message: string) => ({
 }));
 const listTeamsMock = vi.fn();
 const readTeamsMock = vi.fn();
+const exportTeamsActivityMock = vi.fn();
 const formatTeamsListMock = vi.fn(() => 'formatted teams list');
 const formatTeamsReadMock = vi.fn(() => 'formatted teams read');
+const formatTeamsExportMock = vi.fn(() => 'formatted teams export');
 const consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
 vi.mock('@clawpilot/browser/utils/output.js', () => ({
@@ -23,8 +25,10 @@ vi.mock('@clawpilot/browser/utils/output.js', () => ({
 vi.mock('@clawpilot/browser/teams.js', () => ({
   listTeams: listTeamsMock,
   readTeams: readTeamsMock,
+  exportTeamsActivity: exportTeamsActivityMock,
   formatTeamsList: formatTeamsListMock,
   formatTeamsRead: formatTeamsReadMock,
+  formatTeamsExport: formatTeamsExportMock,
 }));
 
 async function createProgram(): Promise<Command> {
@@ -42,8 +46,10 @@ describe('registerTeamsCommands', () => {
     errorMock.mockClear();
     listTeamsMock.mockReset();
     readTeamsMock.mockReset();
+    exportTeamsActivityMock.mockReset();
     formatTeamsListMock.mockClear();
     formatTeamsReadMock.mockClear();
+    formatTeamsExportMock.mockClear();
     consoleLogMock.mockClear();
   });
 
@@ -81,5 +87,34 @@ describe('registerTeamsCommands', () => {
     expect(readTeamsMock).toHaveBeenCalledWith({ id: '/l/chat/chat-1', limit: 20, offset: 0 });
     expect(formatTeamsReadMock).toHaveBeenCalled();
     expect(consoleLogMock).toHaveBeenCalledWith('formatted teams read');
+  });
+
+  it('prints JSON for teams export when requested', async () => {
+    exportTeamsActivityMock.mockResolvedValue({
+      since: '2026-03-24',
+      generatedAt: '2026-04-06T00:00:00.000Z',
+      items: [],
+    });
+
+    const program = await createProgram();
+    await program.parseAsync([
+      'node',
+      'test',
+      'teams',
+      'export',
+      '--since',
+      '2026-03-24',
+      '--json',
+    ]);
+
+    expect(exportTeamsActivityMock).toHaveBeenCalledWith({ since: '2026-03-24' });
+    expect(outputMock).toHaveBeenCalledWith({
+      ok: true,
+      data: {
+        since: '2026-03-24',
+        generatedAt: '2026-04-06T00:00:00.000Z',
+        items: [],
+      },
+    });
   });
 });

--- a/packages/clawpilot-browser/src/__tests__/teams.test.ts
+++ b/packages/clawpilot-browser/src/__tests__/teams.test.ts
@@ -280,6 +280,16 @@ describe('extractTeamsTokensFromMsalCache', () => {
     cached_at: String(Math.floor(Date.now() / 1000)),
   });
 
+  const makeCurrentCacheEntry = (
+    audience: string,
+    secret: string,
+  ): TeamsMsalCacheEntry & { expiresOn: string; cachedAt: string } => ({
+    secret,
+    target: `${audience}/user_impersonation ${audience}/.default`,
+    expiresOn: String(Math.floor(Date.now() / 1000) + 3600),
+    cachedAt: String(Math.floor(Date.now() / 1000)),
+  });
+
   it('extracts all three audience tokens from an MSAL localStorage dump', () => {
     const cache: Record<string, TeamsMsalCacheEntry> = {
       'oid.tid-login.windows.net-accesstoken-clientId-tid-skype': makeCacheEntry(
@@ -297,6 +307,30 @@ describe('extractTeamsTokensFromMsalCache', () => {
     };
 
     const result = extractTeamsTokensFromMsalCache(cache);
+    expect(result).toEqual({
+      skype: 'skype-token-abc',
+      chatSvcAgg: 'csa-token-def',
+      chatSvc: 'ic3-token-ghi',
+    });
+  });
+
+  it('extracts all three audience tokens from current Teams MSAL cache entries', () => {
+    const cache = {
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-skype': makeCurrentCacheEntry(
+        'https://api.spaces.skype.com',
+        'skype-token-abc',
+      ),
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-csa': makeCurrentCacheEntry(
+        'https://chatsvcagg.teams.microsoft.com',
+        'csa-token-def',
+      ),
+      'oid.tid-login.windows.net-accesstoken-clientId-tid-ic3': makeCurrentCacheEntry(
+        'https://ic3.teams.office.com',
+        'ic3-token-ghi',
+      ),
+    };
+
+    const result = extractTeamsTokensFromMsalCache(cache as Record<string, TeamsMsalCacheEntry>);
     expect(result).toEqual({
       skype: 'skype-token-abc',
       chatSvcAgg: 'csa-token-def',
@@ -396,7 +430,32 @@ describe('parseTeamsChatListResponse', () => {
     expect(first?.title).toBe('Design Sync');
     expect(first?.kind).toBe('chat');
     expect(first?.preview).toBe('See you tomorrow');
+    expect(first?.lastMessageAt).toBe('2026-03-18T09:00:00Z');
+    expect(first?.lastMessageAuthor).toBe('Alex');
     expect(second?.title).toContain('user1');
+    expect(second?.preview).toBe('Hello');
+    expect(second?.lastMessageAt).toBe('2026-03-17T08:00:00Z');
+    expect(second?.lastMessageAuthor).toBe('Sam');
+  });
+
+  it('preserves last-message metadata from the current Teams API shape', () => {
+    const raw = [
+      {
+        id: '19:xyz@thread.v2',
+        title: 'Aurora Tech',
+        chatType: 'chat',
+        lastMessage: {
+          content: '<p>same issue</p>',
+          imDisplayName: 'Maicovschi, Maxim',
+          composeTime: '2026-04-06T10:20:22.6870000Z',
+        },
+        hidden: false,
+      },
+    ];
+
+    const [first] = parseTeamsChatListResponse(raw);
+    expect(first?.lastMessageAt).toBe('2026-04-06T10:20:22.6870000Z');
+    expect(first?.lastMessageAuthor).toBe('Maicovschi, Maxim');
   });
 });
 

--- a/packages/clawpilot-browser/src/commands/confluence.ts
+++ b/packages/clawpilot-browser/src/commands/confluence.ts
@@ -1,0 +1,121 @@
+import type { Command } from 'commander';
+import {
+  createConfluenceChildPage,
+  formatConfluencePage,
+  getConfluencePage,
+  resolveConfluenceCredentials,
+  updateConfluencePage,
+} from '@clawpilot/browser/confluence.js';
+import { error, output, success } from '@clawpilot/browser/utils/output.js';
+
+interface ConfluenceCommandOptions {
+  title?: string;
+  body?: string;
+  json: boolean;
+}
+
+export function registerConfluenceCommands(program: Command): void {
+  const confluence = program.command('confluence').description('Read and update Confluence pages');
+  const page = confluence.command('page').description('Work with Confluence pages');
+
+  page
+    .command('get')
+    .description('Look up a Confluence page by URL or page id')
+    .argument('<page-ref>')
+    .option('--json', 'Return structured JSON output', false)
+    .action(
+      async (pageRef: string, options: Pick<ConfluenceCommandOptions, 'json'>): Promise<void> => {
+        try {
+          const auth = resolveConfluenceCredentials();
+          const result = await getConfluencePage({ pageRef, auth });
+          if (options.json) {
+            output(success(result));
+            return;
+          }
+
+          console.log(formatConfluencePage(result));
+        } catch (err) {
+          output(
+            error(
+              'confluence_page_get_failed',
+              err instanceof Error ? err.message : 'Confluence page lookup failed',
+            ),
+          );
+        }
+      },
+    );
+
+  page
+    .command('create-child')
+    .description('Create a child page under a parent Confluence page')
+    .argument('<parent-ref>')
+    .requiredOption('--title <title>', 'Title for the new child page')
+    .requiredOption('--body <storage-body>', 'Confluence storage-format page body')
+    .option('--json', 'Return structured JSON output', false)
+    .action(async (parentRef: string, options: ConfluenceCommandOptions): Promise<void> => {
+      try {
+        const auth = resolveConfluenceCredentials();
+        const result = await createConfluenceChildPage({
+          parentRef,
+          title: options.title ?? '',
+          body: options.body ?? '',
+          auth,
+        });
+        if (options.json) {
+          output(success(result));
+          return;
+        }
+
+        console.log(formatConfluencePage(result));
+      } catch (err) {
+        output(
+          error(
+            'confluence_page_create_failed',
+            err instanceof Error ? err.message : 'Confluence child-page creation failed',
+          ),
+        );
+      }
+    });
+
+  page
+    .command('update')
+    .description('Update a Confluence page title and/or body')
+    .argument('<page-ref>')
+    .option('--title <title>', 'New page title')
+    .option('--body <storage-body>', 'New Confluence storage-format body')
+    .option('--json', 'Return structured JSON output', false)
+    .action(async (pageRef: string, options: ConfluenceCommandOptions): Promise<void> => {
+      if (!options.title && options.body === undefined) {
+        output(
+          error(
+            'missing_update_fields',
+            'Provide --title, --body, or both when updating a Confluence page.',
+          ),
+        );
+        return;
+      }
+
+      try {
+        const auth = resolveConfluenceCredentials();
+        const result = await updateConfluencePage({
+          pageRef,
+          title: options.title,
+          body: options.body,
+          auth,
+        });
+        if (options.json) {
+          output(success(result));
+          return;
+        }
+
+        console.log(formatConfluencePage(result));
+      } catch (err) {
+        output(
+          error(
+            'confluence_page_update_failed',
+            err instanceof Error ? err.message : 'Confluence page update failed',
+          ),
+        );
+      }
+    });
+}

--- a/packages/clawpilot-browser/src/commands/teams.ts
+++ b/packages/clawpilot-browser/src/commands/teams.ts
@@ -1,8 +1,10 @@
 import type { Command } from 'commander';
 import { error, output, success } from '@clawpilot/browser/utils/output.js';
 import {
+  exportTeamsActivity,
   formatTeamsList,
   formatTeamsRead,
+  formatTeamsExport,
   listTeams,
   readTeams,
 } from '@clawpilot/browser/teams.js';
@@ -11,6 +13,7 @@ interface TeamsCommandOptions {
   limit: string;
   offset: string;
   json: boolean;
+  since?: string;
 }
 
 export function registerTeamsCommands(program: Command): void {
@@ -71,6 +74,27 @@ export function registerTeamsCommands(program: Command): void {
       } catch (err) {
         output(
           error('teams_read_failed', err instanceof Error ? err.message : 'Teams read failed'),
+        );
+      }
+    });
+
+  teams
+    .command('export')
+    .description('Export Teams activity since a date')
+    .requiredOption('--since <date>', 'Inclusive ISO date or datetime lower bound')
+    .option('--json', 'Return structured JSON output', false)
+    .action(async (options: TeamsCommandOptions): Promise<void> => {
+      try {
+        const result = await exportTeamsActivity({ since: options.since ?? '' });
+        if (options.json) {
+          output(success(result));
+          return;
+        }
+
+        console.log(formatTeamsExport(result));
+      } catch (err) {
+        output(
+          error('teams_export_failed', err instanceof Error ? err.message : 'Teams export failed'),
         );
       }
     });

--- a/packages/clawpilot-browser/src/confluence.ts
+++ b/packages/clawpilot-browser/src/confluence.ts
@@ -1,0 +1,280 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_JIRA_CONFIG_PATH = `${process.env.HOME ?? ''}/.config/.jira/.config.yml`;
+
+type FetchFn = typeof globalThis.fetch;
+
+export interface JiraCliConfig {
+  login?: string;
+}
+
+export interface ConfluenceAuth {
+  siteBaseUrl: string;
+  apiBaseUrl: string;
+  login: string;
+  apiToken: string;
+}
+
+export interface ConfluencePage {
+  id: string;
+  status: string;
+  title: string;
+  spaceId: string;
+  parentId: string | null;
+  versionNumber: number;
+  body: string;
+  webUrl: string;
+}
+
+export interface GetConfluencePageOptions {
+  pageRef: string;
+  auth: ConfluenceAuth;
+}
+
+export interface CreateConfluenceChildPageOptions {
+  parentRef: string;
+  title: string;
+  body: string;
+  auth: ConfluenceAuth;
+}
+
+export interface UpdateConfluencePageOptions {
+  pageRef: string;
+  title?: string;
+  body?: string;
+  auth: ConfluenceAuth;
+}
+
+interface ConfluencePageApiResponse {
+  id: string;
+  status: string;
+  title: string;
+  spaceId: string;
+  parentId?: string;
+  version: {
+    number: number;
+  };
+  body?: {
+    storage?: {
+      representation?: string;
+      value?: string;
+    };
+  };
+  _links?: {
+    webui?: string;
+  };
+}
+
+export function parseConfluencePageId(ref: string): string | null {
+  const trimmed = ref.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const segments = url.pathname.split('/');
+    const pagesIndex = segments.findIndex((segment) => segment === 'pages');
+    const pageId = pagesIndex >= 0 ? segments[pagesIndex + 1] : undefined;
+    return pageId && /^\d+$/.test(pageId) ? pageId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveConfluenceCredentials(
+  env: Partial<NodeJS.ProcessEnv> = process.env,
+  jiraConfig: JiraCliConfig = readJiraCliConfig(env.JIRA_CONFIG_FILE),
+): ConfluenceAuth {
+  const siteSource = env.CONFLUENCE_SITE_URL ?? env.JIRA_URL;
+  if (!siteSource) {
+    throw new Error('Confluence site URL not configured. Set CONFLUENCE_SITE_URL or JIRA_URL.');
+  }
+
+  const apiToken = env.CONFLUENCE_API_TOKEN ?? env.JIRA_API_TOKEN;
+  if (!apiToken) {
+    throw new Error(
+      'Confluence API token not configured. Set CONFLUENCE_API_TOKEN or JIRA_API_TOKEN.',
+    );
+  }
+
+  const login = env.CONFLUENCE_LOGIN ?? env.JIRA_LOGIN ?? jiraConfig.login;
+  if (!login) {
+    throw new Error(
+      'Confluence login not configured. Set CONFLUENCE_LOGIN/JIRA_LOGIN or configure jira-cli login.',
+    );
+  }
+
+  const siteBaseUrl = new URL(siteSource).origin;
+  return {
+    siteBaseUrl,
+    apiBaseUrl: `${siteBaseUrl}/wiki/api/v2`,
+    login,
+    apiToken,
+  };
+}
+
+export async function getConfluencePage(
+  options: GetConfluencePageOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<ConfluencePage> {
+  const pageId = requireConfluencePageId(options.pageRef);
+  const raw = await requestConfluencePage(
+    `${options.auth.apiBaseUrl}/pages/${pageId}?body-format=storage`,
+    options.auth,
+    fetchImpl,
+  );
+  return normalizeConfluencePage(raw, options.auth);
+}
+
+export async function createConfluenceChildPage(
+  options: CreateConfluenceChildPageOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<ConfluencePage> {
+  const parent = await getConfluencePage(
+    { pageRef: options.parentRef, auth: options.auth },
+    fetchImpl,
+  );
+  const raw = await requestConfluencePage(
+    `${options.auth.apiBaseUrl}/pages`,
+    options.auth,
+    fetchImpl,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        spaceId: parent.spaceId,
+        status: 'current',
+        title: options.title,
+        parentId: parent.id,
+        body: {
+          representation: 'storage',
+          value: options.body,
+        },
+      }),
+    },
+  );
+  return normalizeConfluencePage(raw, options.auth);
+}
+
+export async function updateConfluencePage(
+  options: UpdateConfluencePageOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<ConfluencePage> {
+  if (!options.title && options.body === undefined) {
+    throw new Error('Provide a new title, body, or both when updating a Confluence page.');
+  }
+
+  const current = await getConfluencePage(
+    { pageRef: options.pageRef, auth: options.auth },
+    fetchImpl,
+  );
+  const raw = await requestConfluencePage(
+    `${options.auth.apiBaseUrl}/pages/${current.id}`,
+    options.auth,
+    fetchImpl,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        id: current.id,
+        status: current.status,
+        title: options.title ?? current.title,
+        spaceId: current.spaceId,
+        parentId: current.parentId ?? undefined,
+        body: {
+          representation: 'storage',
+          value: options.body ?? current.body,
+        },
+        version: {
+          number: current.versionNumber + 1,
+        },
+      }),
+    },
+  );
+  return normalizeConfluencePage(raw, options.auth);
+}
+
+export function formatConfluencePage(page: ConfluencePage): string {
+  const lines = [
+    page.title,
+    `ID: ${page.id}`,
+    `Status: ${page.status}`,
+    `Space ID: ${page.spaceId}`,
+  ];
+
+  if (page.parentId) {
+    lines.push(`Parent ID: ${page.parentId}`);
+  }
+
+  lines.push(`Version: ${page.versionNumber}`, `URL: ${page.webUrl}`);
+
+  if (page.body) {
+    lines.push('', page.body);
+  }
+
+  return lines.join('\n');
+}
+
+function readJiraCliConfig(configPath = DEFAULT_JIRA_CONFIG_PATH): JiraCliConfig {
+  if (!configPath || !existsSync(configPath)) {
+    return {};
+  }
+
+  const contents = readFileSync(configPath, 'utf8');
+  const match = contents.match(/^login:\s*(.+)\s*$/m);
+  if (!match) {
+    return {};
+  }
+
+  return {
+    login: match[1]?.trim().replace(/^['"]|['"]$/g, ''),
+  };
+}
+
+function requireConfluencePageId(pageRef: string): string {
+  const pageId = parseConfluencePageId(pageRef);
+  if (!pageId) {
+    throw new Error('Expected a numeric Confluence page id or a Confluence page URL.');
+  }
+  return pageId;
+}
+
+async function requestConfluencePage(
+  url: string,
+  auth: ConfluenceAuth,
+  fetchImpl: FetchFn,
+  init?: RequestInit,
+): Promise<ConfluencePageApiResponse> {
+  const response = await fetchImpl(url, {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      authorization: `Basic ${Buffer.from(`${auth.login}:${auth.apiToken}`).toString('base64')}`,
+      'content-type': 'application/json',
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Confluence request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as ConfluencePageApiResponse;
+}
+
+function normalizeConfluencePage(
+  raw: ConfluencePageApiResponse,
+  auth: ConfluenceAuth,
+): ConfluencePage {
+  return {
+    id: raw.id,
+    status: raw.status,
+    title: raw.title,
+    spaceId: raw.spaceId,
+    parentId: raw.parentId ?? null,
+    versionNumber: raw.version.number,
+    body: raw.body?.storage?.value ?? '',
+    webUrl: raw._links?.webui
+      ? `${auth.siteBaseUrl}${raw._links.webui}`
+      : `${auth.siteBaseUrl}/wiki/pages/${raw.id}`,
+  };
+}

--- a/packages/clawpilot-browser/src/index.ts
+++ b/packages/clawpilot-browser/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { registerAuthCommands } from '@clawpilot/browser/commands/auth.js';
+import { registerConfluenceCommands } from '@clawpilot/browser/commands/confluence.js';
 import { registerHealthCommands } from '@clawpilot/browser/commands/health.js';
 import { registerTeamsCommands } from '@clawpilot/browser/commands/teams.js';
 import { registerWebCommands } from '@clawpilot/browser/commands/web.js';
@@ -15,6 +16,7 @@ program
 
 registerHealthCommands(program);
 registerAuthCommands(program);
+registerConfluenceCommands(program);
 registerTeamsCommands(program);
 registerWebCommands(program);
 

--- a/packages/clawpilot-browser/src/teams.ts
+++ b/packages/clawpilot-browser/src/teams.ts
@@ -35,6 +35,8 @@ export interface TeamsListCandidate {
   title: string;
   path: string;
   preview: string | null;
+  lastMessageAt?: string | null;
+  lastMessageAuthor?: string | null;
   order: number;
 }
 
@@ -81,6 +83,27 @@ export interface TeamsReadOptions extends TeamsListOptions {
   id: string;
 }
 
+export interface TeamsExportOptions {
+  since: string;
+}
+
+export interface TeamsExportItem {
+  id: string;
+  kind: TeamsItemKind;
+  title: string;
+  path: string;
+  link: string;
+  preview: string | null;
+  lastMessageAt: string;
+  lastMessageAuthor: string | null;
+}
+
+export interface TeamsExportResult {
+  since: string;
+  generatedAt: string;
+  items: TeamsExportItem[];
+}
+
 interface RawTeamsListNode {
   href: string | null;
   text: string;
@@ -119,8 +142,10 @@ interface TeamsAuthProbeResult {
 export interface TeamsMsalCacheEntry {
   secret: string;
   target: string;
-  expires_on: string;
-  cached_at: string;
+  expires_on?: string;
+  cached_at?: string;
+  expiresOn?: string;
+  cachedAt?: string;
 }
 
 export interface TeamsTokenSet {
@@ -270,6 +295,34 @@ export function formatTeamsRead(result: TeamsReadResult): string {
   return lines.join('\n');
 }
 
+export function formatTeamsExport(result: TeamsExportResult): string {
+  const lines = [
+    `Teams activity since ${result.since} (${result.items.length} conversations)`,
+    `Generated at: ${result.generatedAt}`,
+    '',
+  ];
+
+  if (result.items.length === 0) {
+    lines.push('- None');
+    return lines.join('\n');
+  }
+
+  for (const item of result.items) {
+    lines.push(`- ${item.title}`);
+    lines.push(`  ID: ${item.id}`);
+    lines.push(`  Link: ${item.link}`);
+    lines.push(`  Last message: ${item.lastMessageAt}`);
+    if (item.lastMessageAuthor) {
+      lines.push(`  Author: ${item.lastMessageAuthor}`);
+    }
+    if (item.preview) {
+      lines.push(`  Preview: ${item.preview}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 export function detectTeamsShellError(snapshot: TeamsShellSnapshot): string | null {
   const normalizedButtons = snapshot.buttonTexts.map((button) => button.trim().toLowerCase());
   const normalizedBody = snapshot.bodyText.trim().toLowerCase();
@@ -360,12 +413,12 @@ export function extractTeamsTokensFromMsalCache(
   > = {};
 
   for (const entry of Object.values(cache)) {
-    const expiresAt = parseEpochSeconds(entry.expires_on) ?? 0;
+    const expiresAt = parseEpochSeconds(entry.expires_on ?? entry.expiresOn) ?? 0;
     if (expiresAt <= nowEpochSeconds) {
       continue;
     }
 
-    const cachedAt = parseEpochSeconds(entry.cached_at) ?? 0;
+    const cachedAt = parseEpochSeconds(entry.cached_at ?? entry.cachedAt) ?? 0;
     for (const [key, audience] of Object.entries(TEAMS_TOKEN_AUDIENCES)) {
       const tokenKey = key as keyof TeamsTokenSet;
       if (
@@ -399,14 +452,26 @@ export function parseTeamsChatListResponse(
           id: string;
           type: string;
           threadProperties?: { topic?: string; threadType?: string };
-          lastMessage?: { composetime?: string; imdisplayname?: string; content?: string };
+          lastMessage?: {
+            composetime?: string;
+            composeTime?: string;
+            imdisplayname?: string;
+            imDisplayName?: string;
+            content?: string;
+          };
         }>;
       }
     | Array<{
         id: string;
         title: string | null;
         chatType: string;
-        lastMessage?: { content?: string; imdisplayname?: string; composetime?: string };
+        lastMessage?: {
+          content?: string;
+          imdisplayname?: string;
+          imDisplayName?: string;
+          composetime?: string;
+          composeTime?: string;
+        };
         members?: Array<{ objectId: string }>;
         hidden?: boolean;
       }>,
@@ -426,6 +491,8 @@ export function parseTeamsChatListResponse(
         title: c.threadProperties?.topic ?? c.id,
         path: buildTeamsChatPath(c.id),
         preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
+        lastMessageAt: c.lastMessage?.composetime ?? c.lastMessage?.composeTime ?? null,
+        lastMessageAuthor: c.lastMessage?.imdisplayname ?? c.lastMessage?.imDisplayName ?? null,
         order: i,
       }));
   }
@@ -439,6 +506,8 @@ export function parseTeamsChatListResponse(
       title: c.title ?? (c.members?.map((m) => m.objectId).join(', ') || 'Unnamed chat'),
       path: buildTeamsChatPath(c.id),
       preview: c.lastMessage?.content ? stripHtml(c.lastMessage.content) : null,
+      lastMessageAt: c.lastMessage?.composetime ?? c.lastMessage?.composeTime ?? null,
+      lastMessageAuthor: c.lastMessage?.imdisplayname ?? c.lastMessage?.imDisplayName ?? null,
       order: i,
     }));
 }
@@ -589,6 +658,54 @@ export async function listTeamsDirect(
   return buildTeamsListResult(items, options);
 }
 
+export async function exportTeamsActivity(
+  options: TeamsExportOptions,
+  fetchImpl: FetchFn = globalThis.fetch,
+): Promise<TeamsExportResult> {
+  const sinceDate = new Date(options.since);
+  if (Number.isNaN(sinceDate.getTime())) {
+    throw new Error('since must be a valid ISO date or datetime');
+  }
+
+  return withTeamsPage(async (page) => {
+    await loadTeamsShell(page);
+    await ensureTeamsAuthReady(page);
+    await makeWindowUnobtrusive(page);
+
+    const tokens = await extractTeamsTokensFromPage(page);
+    if (!tokens) {
+      throw new Error('Teams tokens were not available in the Teams app session.');
+    }
+
+    const items = await fetchTeamsListCandidatesDirect(tokens, fetchImpl);
+    const filtered = items
+      .filter((item): item is TeamsListCandidate & { lastMessageAt: string } => {
+        if (!item.lastMessageAt) {
+          return false;
+        }
+
+        const lastMessageDate = new Date(item.lastMessageAt);
+        return !Number.isNaN(lastMessageDate.getTime()) && lastMessageDate >= sinceDate;
+      })
+      .map((item) => ({
+        id: item.id,
+        kind: item.kind,
+        title: item.title,
+        path: item.path,
+        link: `${TEAMS_BASE_URL}${item.path}`,
+        preview: item.preview,
+        lastMessageAt: item.lastMessageAt,
+        lastMessageAuthor: item.lastMessageAuthor ?? null,
+      }));
+
+    return {
+      since: options.since,
+      generatedAt: new Date().toISOString(),
+      items: filtered,
+    };
+  });
+}
+
 export async function readTeamsDirect(
   tokens: TeamsTokenSet,
   options: TeamsReadOptions,
@@ -633,7 +750,14 @@ async function extractTeamsTokensFromPage(page: Page): Promise<TeamsTokenSet | n
   const msalEntries = await page.evaluate(() => {
     const entries: Record<
       string,
-      { secret: string; target: string; expires_on: string; cached_at: string }
+      {
+        secret: string;
+        target: string;
+        expires_on?: string;
+        cached_at?: string;
+        expiresOn?: string;
+        cachedAt?: string;
+      }
     > = {};
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
@@ -644,8 +768,10 @@ async function extractTeamsTokensFromPage(page: Page): Promise<TeamsTokenSet | n
           entries[key] = val as {
             secret: string;
             target: string;
-            expires_on: string;
-            cached_at: string;
+            expires_on?: string;
+            cached_at?: string;
+            expiresOn?: string;
+            cachedAt?: string;
           };
         }
       } catch {
@@ -1270,7 +1396,10 @@ function getTeamsConversationIdFromTarget(id: string): string | null {
   return encodedConversationId ? decodeURIComponent(encodedConversationId) : null;
 }
 
-function parseEpochSeconds(value: string): number | null {
+function parseEpochSeconds(value: string | undefined): number | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@clawpilot/browser':
+        specifier: workspace:*
+        version: link:packages/clawpilot-browser
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,25 +12,25 @@ importers:
         specifier: workspace:*
         version: link:packages/clawpilot-browser
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 10.0.1
         version: 10.0.1(eslint@10.0.3)
       eslint:
-        specifier: ^10.0.3
+        specifier: 10.0.3
         version: 10.0.3
       eslint-config-prettier:
-        specifier: ^10.1.8
+        specifier: 10.1.8
         version: 10.1.8(eslint@10.0.3)
       husky:
-        specifier: ^9.1.7
+        specifier: 9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^16.4.0
+        specifier: 16.4.0
         version: 16.4.0
       prettier:
-        specifier: ^3.8.1
+        specifier: 3.8.1
         version: 3.8.1
       typescript-eslint:
-        specifier: ^8.57.1
+        specifier: 8.57.1
         version: 8.57.1(eslint@10.0.3)(typescript@5.9.3)
 
   packages/clawpilot-browser:


### PR DESCRIPTION
## Summary
- add Teams activity export support plus new Confluence page helpers and CLI commands in `@clawpilot/browser`
- add the repo-local weekly work summary skill, references, and extension wrapper
- update repo docs and plan material for the weekly summary workflow

## Verification
- pnpm verify
